### PR TITLE
Add configuration file for cpplint

### DIFF
--- a/content/CPPLINT.cfg
+++ b/content/CPPLINT.cfg
@@ -1,0 +1,8 @@
+filter=-whitespace/tab
+filter=-whitespace/line-length
+filter=-whitespace/braces
+filter=-legal/copyright
+filter=-whitespace/comments
+filter=-build/header_guard
+filter=-readability/multiline_comment
+filter=-readability/casting


### PR DESCRIPTION
Use `CPPLINT.cfg` in the `content/` folder to configure the use of `cpplint` as linter.

To test it, install `cpplint` as PIP package and run it against a file:

```
$ pip install cpplint

$ cpplint content/common/test/open.c
content/common/test/open.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
content/common/test/open.c:7:  Include the directory when naming header files  [build/include_subdir] [4]
content/common/test/open.c:8:  Include the directory when naming header files  [build/include_subdir] [4]
Done processing content/common/test/open.c
Total errors found: 3
```

A full list of configuration options is [here](https://github.com/cpplint/cpplint/blob/develop/cpplint.py#L287).

A sample extensive configuration file is [here](https://github.com/sider/runners/blob/HEAD/images/cpplint/sider_recommended_CPPLINT.cfg).