### PR TITLE
.github: Disable JSCPD validation

### DIFF
--- a/.github/workflows/.jscpd.json
+++ b/.github/workflows/.jscpd.json
@@ -1,0 +1,5 @@
+{
+  "reporters": ["console"],
+  "ignore": ["**/*.svg", "**/_site/**"],
+  "absolute": true
+}


### PR DESCRIPTION
Disable JSCPD validation (copy-paste detection). This tampers with SVG files.