### PR TITLE
Only trigger super-linter on pushes to `master` and on pull requests

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,6 +1,10 @@
 name: Lint Code Base
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   superlinter:


### PR DESCRIPTION
Triggering super-linter on every push causes duplicate runs when pushing commits to a branch within a fork from which there is a pull request. It runs once within the fork for the push and again, on the same content, within the main repo for the pull request.