### PR TITLE
Disable clang-format from super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,6 +20,7 @@ jobs:
           # Don't check already existent files
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_CLANG_FORMAT: false
           LINTER_RULES_PATH: /.github/workflows/
           MARKDOWN_CONFIG_FILE: config/config.json
           MARKDOWN_CUSTOM_RULE_GLOBS: rules/rules.js

--- a/content/.clang-format
+++ b/content/.clang-format
@@ -1,6 +1,0 @@
-BasedOnStyle:		WebKit
-TabWidth:		8
-IndentWidth:		8
-UseTab:			Always
-ColumnLimit:		132
-PointerAlignment:	Right


### PR DESCRIPTION
Disable clang-format from super-linter

To see how this works and the amounts of seemingly unconfigurable issues that appear:

1. Install [using `pip`](https://pypi.org/project/clang-format/). This installs a newer 14 version.

1. Dump the current configuration to get all (?) the configuration options:

   ```
   clang-format -style=llvm -dump-config > current_clang-format
   ```
 
1. See [configuration options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

1. To emulate the `super-linter` behavior, run:

   ```
   clang-format --dry-run -Werror chapters/data/lab/support/alloc-size/alloc_size.c
   ```

There are `-Wclang-format-violation` warnings that we weren't able to get rid of. We didn't find the [configuration options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html). Some situations:
- Having a Tab between the name of a macro and its value. `clang-format` requires to use a certain number of space. We didn't find any option to configure the use of tabs.
- `clang-format` is strict to the use of spaces around arithmetic operators. For example, using `int a = b-1;` triggers a warning / error to have it written as `int a = b - 1;`. This seems a bit too much and should be configurable. But again, we didn't find an option to disable this.

A rather complete configuration file is [the one used by cpp_weekly](https://github.com/lefticus/cpp_weekly/blob/master/.clang-format).