### PR TITLE
Improve process creation demos in the Compute lecture

### DIFF
--- a/content/chapters/compute/lecture/demo/create-process/.gitignore
+++ b/content/chapters/compute/lecture/demo/create-process/.gitignore
@@ -1,1 +1,5 @@
 /fork_exec
+/fork
+/multiple_forks
+/posix_spawn
+/system

--- a/content/chapters/compute/lecture/demo/create-process/Makefile.linux
+++ b/content/chapters/compute/lecture/demo/create-process/Makefile.linux
@@ -1,2 +1,2 @@
-BINARIES = fork_exec posix_spawn system
+BINARIES = fork fork_exec multiple_forks posix_spawn system
 include ../../../../../common/makefile/multiple.mk

--- a/content/chapters/compute/lecture/demo/create-process/README.md
+++ b/content/chapters/compute/lecture/demo/create-process/README.md
@@ -1,0 +1,81 @@
+# Create Processes
+
+These are some examples on how to create processes using various APIs.
+
+## Build
+
+To build the C examples on Linux, run `make -f Makefile.linux`.
+To build `create_process.c` (on Windows), run `make -f Makefile.win`.
+
+## Running
+
+### `system.c`
+
+This is the most straightforward way to create a process in C.
+Just specify the path of the new process, together with all its arguments as a string.
+
+### `posix_spawn.c`
+
+`posix_spawn()` is similar to `system()`, but more granular.
+Now we can specify the `argv` and `envp` received by the spawned process's `main()` function.
+
+### `create_process.c`
+
+The Windows **syscall** `CreateProcess()` is quite similar to the Linux **library function** `posix_spawn()`.
+It receives [(many) more arguments](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa).
+However, the main difference is that in order to run a specific command in the terminal, `CreateProcess()` must also be specified which terminal to use.
+In our example, we use the command prompt (`cmd`).
+Hence, the first argumetn we give to `CreateProcess()` is `"cmd /s ls"`.
+
+### `fork.c`
+
+`fork()` is the underlying **library call, not system call** that both `system()` and `posix_spawn()` use to create the new process.
+
+Run the code and see how `fork()` returns **twice**.
+It creates another process and then returns a different value to each of the two processes:
+- it returns 0 to the child process
+- it returns the PID of the child process to the parent
+
+### `multiple_forks.c`
+
+Unlike the example in `fork.c`, this one calls `fork()` twice more.
+Can you tell how many processes there will be in the end?
+
+Run the code and analyse the process hierarchy using the following output:
+
+```
+After first fork: PID = 8667; PPID = 6579
+ * first fork()
+ -- Press ENTER to continue ...
+After first fork: PID = 8668; PPID = 8667
+ * first fork()
+ -- Press ENTER to continue ...
+
+After second fork: PID = 8667; PPID = 6579
+ * second fork()
+ -- Press ENTER to continue ...
+After second fork: PID = 8759; PPID = 8667
+ * second fork()
+ -- Press ENTER to continue ...
+
+After second fork: PID = 8668; PPID = 8667
+ * second fork()
+ -- Press ENTER to continue ...
+After second fork: PID = 8760; PPID = 8668
+ * second fork()
+ -- Press ENTER to continue ...
+```
+
+Note that after they're created, the processes act independently.
+Therefore, you will to press `Enter` for each newly created process (as prompted by `wait_for_input()`.
+
+Investigate the process hierarchy after each `fork()`.
+In the end, it should look like this:
+
+```console
+student@os:~/.../lab/support/create-process$ $ pstree -p 8667  # 8667 is the PID of the first multiple_forks process
+multiple_forks(8667)─┬─multiple_forks(8668)─┬─multiple_forks(8760)───multiple_forks(8764)
+                     │                      └─multiple_forks(8763)
+                     ├─multiple_forks(8759)───multiple_forks(8762)
+                     └─multiple_forks(8761)
+```

--- a/content/chapters/compute/lecture/demo/create-process/fork.c
+++ b/content/chapters/compute/lecture/demo/create-process/fork.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+
+#include "utils.h"
+
+int main(void)
+{
+	pid_t pid;
+	int rc;
+	int exit_code;
+
+	pid = fork();
+	switch (pid) {
+	case -1:	/* Error */
+		DIE(1, "fork");
+		break;
+
+	case 0:		/* Child process */
+		printf("[child] PID = %d; PPID = %d\n", getpid(), getppid());
+
+		sleep(5);
+		return 42;
+
+	default:	/* Parent process */
+		printf("[parent] PID = %d; child PID = %d; Waiting...\n",
+			getpid(), pid);
+
+		rc = waitpid(pid, &exit_code, 0);
+		DIE(rc < 0, "waitpid");
+
+		if (WIFEXITED(exit_code))
+			printf("[parent] Child exited with code %d\n",
+				WEXITSTATUS(exit_code));
+		break;
+	}
+
+	return 0;
+}

--- a/content/chapters/compute/lecture/demo/create-process/multiple_forks.c
+++ b/content/chapters/compute/lecture/demo/create-process/multiple_forks.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "utils.h"
+
+static void wait_for_input(const char *msg)
+{
+	char buf[32];
+
+	printf(" * %s\n", msg);
+	printf(" -- Press ENTER to continue ...\n");
+	fflush(stdout);
+	fgets(buf, 32, stdin);
+}
+
+int main(void)
+{
+	pid_t pid;
+	int rc;
+	int exit_code;
+
+	fork();
+	printf("After first fork: PID = %d; PPID = %d\n", getpid(), getppid());
+	wait_for_input("first fork()");
+
+	fork();
+	printf("After second fork: PID = %d; PPID = %d\n", getpid(), getppid());
+	wait_for_input("second fork()");
+
+	pid = fork();
+	wait_for_input("third fork()");
+
+	switch (pid) {
+	case -1:	/* Error */
+		DIE(1, "fork");
+		break;
+
+	case 0: 	/* Child process */
+		sleep(1);
+		printf("[child] PID = %d; PPID = %d\n", getpid(), getppid());
+
+		break;
+
+	default: 	/* Parent process */
+		printf("[parent] PID = %d; child PID = %d; Waiting...\n",
+			getpid(), pid);
+
+		rc = waitpid(pid, &exit_code, 0);
+		DIE(rc < 0, "waitpid");
+
+		break;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
The lecture was missing a simple `fork()` demo. It jumped straight to `fork()` + `exec()`. A more granular introduction feels needed.