### PR TITLE
Fix Thread init argument

### DIFF
--- a/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_condition.py
+++ b/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_condition.py
@@ -31,7 +31,7 @@ def main():
     event = Condition()
 
     # Create and start the worker threads.
-    thread_pool = [Thread(target=worker, args=(sem, i)) for i in range(NUM_WORKERS)]
+    thread_pool = [Thread(target=worker, args=(event, i)) for i in range(NUM_WORKERS)]
     for t in thread_pool:
         t.daemon = True
         t.start()


### PR DESCRIPTION
When creating threads, the wrong variable is given as an argument (sem instead of event), probably left over from the other program in this folder. All this fix does is change that variable.