### PR TITLE
compute/lab: Fix initialization for var variable

### DIFF
--- a/content/chapters/compute/lab/support/race-condition/c/race_condition_tls.c
+++ b/content/chapters/compute/lab/support/race-condition/c/race_condition_tls.c
@@ -7,7 +7,7 @@
 #define NUM_ITER 10000000
 
 /* TODO 1: Add the `__thread` keyword to the declaration below. */
-static __thread int var;
+static int var;
 
 void *increment_var(void *arg)
 {


### PR DESCRIPTION
var variable shouldn't be initialized with `__thread` keyword since this is a task in the lab.

Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>