### PR TITLE
common/makefile: Get rid of -Werror

### DIFF
--- a/content/common/makefile/defs.mk
+++ b/content/common/makefile/defs.mk
@@ -6,6 +6,6 @@ UTILS_DIR := $(MAKEFILE_DIR)../utils
 LOGGER_DIR := $(UTILS_DIR)/log
 
 CPPFLAGS += -I$(UTILS_DIR) -I$(LOGGER_DIR)
-CFLAGS += -g -Wall -Wextra -Werror
+CFLAGS += -g -Wall -Wextra
 LOGGER_OBJ = log.o
 LOGGER = $(LOGGER_DIR)/$(LOGGER_OBJ)


### PR DESCRIPTION
This is annoying and doesn't make sense when you create program snippets that do not (yet) call functions. You end up with an error such as:

```
error: ... defined but not used [-Werror=unused-function]
```

There are probably other use cases.