### PR TITLE
Update infrastructure to address cpplint errors

### DIFF
--- a/content/CPPLINT.cfg
+++ b/content/CPPLINT.cfg
@@ -6,3 +6,4 @@ filter=-whitespace/comments
 filter=-build/header_guard
 filter=-readability/multiline_comment
 filter=-readability/casting
+linelength=120

--- a/content/common/makefile/defs.mk
+++ b/content/common/makefile/defs.mk
@@ -2,10 +2,11 @@ CC = gcc
 
 # Get the relative path to the directory of the current makefile.
 MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+INCLUDES_DIR := $(MAKEFILE_DIR)..
 UTILS_DIR := $(MAKEFILE_DIR)../utils
 LOGGER_DIR := $(UTILS_DIR)/log
 
-CPPFLAGS += -I$(UTILS_DIR) -I$(LOGGER_DIR)
+CPPFLAGS += -I$(INCLUDES_DIR)
 CFLAGS += -g -Wall -Wextra
 LOGGER_OBJ = log.o
 LOGGER = $(LOGGER_DIR)/$(LOGGER_OBJ)

--- a/content/common/utils/log/CPPLINT.cfg
+++ b/content/common/utils/log/CPPLINT.cfg
@@ -1,0 +1,1 @@
+exclude_files=log\.c

--- a/content/common/utils/utils.h
+++ b/content/common/utils/utils.h
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "log.h"
+#include "log/log.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This changes the following:
- Allows lines up to 120 characters long in `CPPLINT.cfg`
- Changes makefile workflow to force users to include the directory of
"utils.h" or "log.h" like so: `#include "utils/utils.h"`
- Ignores `log.c` from cpplint because that code is taken from https://github.com/rxi/log.c