### PR TITLE
CPPLINT.cfg: Remove runtime/int check

### DIFF
--- a/content/CPPLINT.cfg
+++ b/content/CPPLINT.cfg
@@ -6,4 +6,5 @@ filter=-whitespace/comments
 filter=-build/header_guard
 filter=-readability/multiline_comment
 filter=-readability/casting
+filter=-runtime/int
 linelength=120


### PR DESCRIPTION
The `runtime/int` cppcheck finds uses of `short`, `long` and `long long` and suggest replacing them with `u?intXX(_t)?`
(https://clang.llvm.org/extra/clang-tidy/checks/google/runtime-int.html). This is too much / pedantic, so we remove it.