### PR TITLE
workflows: Configure and disable Markdown linter options

### DIFF
--- a/.github/workflows/config/config.json
+++ b/.github/workflows/config/config.json
@@ -1,8 +1,11 @@
 {
 	"default": true,
-	"MD048": { "style": "backtick" },
-	"MD046": { "style": "fenced" },
+	"MD004": false,
 	"MD029": { "style": "one" },
+	"MD035": { "style": ["---", "----"] },
+	"MD041": false,
+	"MD046": { "style": "fenced" },
+	"MD048": { "style": "backtick" },
 	"line-length": false,
 	"no-hard-tabs": false
 }


### PR DESCRIPTION
* Disable **MD004** to allow use of both `+` and `-` in lists mainly for quizzes
* Configure **MD035** to allow the use of `----`
* Disable **MD041** to allow files to start without a top-level header