### PR TITLE
Add I/O lab to `config.yml`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,6 +119,37 @@ docusaurus:
           - Arena:
               location: content/chapters/software-stack/lab
               name: content/arena
+        - I/O:
+          - Overview:
+            location: content/chapters/io/lab
+            name: content/overview
+          - Introduction:
+            location: content/chapters/io/lab
+            name: content/introduction
+          - File Handlers:
+            location: content/chapters/io/lab
+            name: content/file-handlers
+          - File Descriptors:
+            location: content/chapters/io/lab
+            name: content/file-descriptors
+          - Redirections:
+            location: content/chapters/io/lab
+            name: content/redirections
+          - Pipes:
+            location: content/chapters/io/lab
+            name: content/pipes
+          - File Mappings:
+            location: content/chapters/io/lab
+            name: content/file-mappings
+          - I/O Internals:
+            location: content/chapters/io/lab
+            name: content/io-internals
+          - Devices:
+            location: content/chapters/io/lab
+            name: content/devices
+          - Arena:
+            location: content/chapters/io/lab
+            name: content/arena
     static_assets:
       - slides/Compute: /build/make_assets/content/chapters/compute/lecture/_site
       - slides/Software-Stack: /build/make_assets/content/chapters/software-stack/lecture/_site


### PR DESCRIPTION
The first part of the I/O lab was added in https://github.com/open-education-hub/operating-systems/pull/30.