### PR TITLE
workflows: Configure and disable Markdown linter options

### DIFF
--- a/.github/workflows/config/config.json
+++ b/.github/workflows/config/config.json
@@ -1,8 +1,14 @@
 {
 	"default": true,
 	"MD004": false,
+	"MD024": false,
 	"MD029": { "style": "one" },
-	"MD035": { "style": ["---", "----"] },
+	"MD033": {
+        "allowed_elements": [
+          "img"
+        ]
+    },
+	"MD035": false,
 	"MD041": false,
 	"MD046": { "style": "fenced" },
 	"MD048": { "style": "backtick" },

--- a/.github/workflows/rules/md101.js
+++ b/.github/workflows/rules/md101.js
@@ -10,9 +10,6 @@ const keywords = [
     new WordPattern("ping"),
     new WordPattern("traceroute"),
     new WordPattern("sudo"),
-    new WordPattern("(?<!(system |ISRG ))root(?! ca)", { suggestion: "root" }),// match "root", but not "root CA", "MacOS System Root" and "ISRG Root X1"
-    new WordPattern("true"),
-    new WordPattern("false"),
     new WordPattern("jps"),
     new WordPattern("name=value"),
     new WordPattern("key=value"),

--- a/.github/workflows/rules/md104.js
+++ b/.github/workflows/rules/md104.js
@@ -1,5 +1,21 @@
 "use strict";
 
+function strip_words(line) {
+  const URL_REGEX = new RegExp(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/gi);
+  const QUOTED_WORD_REGEX = new RegExp(/\`(.*?)\`|\"(.*?)\"/g)
+  const IGNORED_REGEXES = [
+    URL_REGEX,
+    QUOTED_WORD_REGEX,
+    'i.e.',
+    'e.g.',
+    '...'
+  ]
+
+  IGNORED_REGEXES.forEach((i_word) => line = line.replace(i_word, ''))
+
+  return line
+}
+
 module.exports = {
   names: ["MD104", "one line per sentence"],
   description: "one line (and only one line) per sentence",
@@ -10,10 +26,11 @@ module.exports = {
     })) {
       var actual_lines = inline.content.split("\n");
       actual_lines.forEach((line, index, arr) => {
-		let outside = true;
+        line = strip_words(line)
+        let outside = true;
 		let count = 0;
 		Array.from(line).forEach((char) => {
-			if ((char == "." || char == "?" || char == "!" || char == ";" || char == ":") && outside) {
+			if ((char == "." || char == "?" || char == "!" || char == ";") && outside) {
 				count++;
 			}
 			if (char == "`") outside = !outside;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ Use phrases like "find the flag", "run this command", "download the tool".
 ## Images
 
 Images and diagrams would ideally be animated on slides.
-Aim to use reveal.js features to animate drawing of diagrams.
+Aim to use `reveal.js` features to animate drawing of diagrams.
 
-If reveal.js drawing is difficult, use [draw.io](https://app.diagrams.net/) to create diagrams.
+If `reveal.js` drawing is difficult, use [draw.io](https://app.diagrams.net/) to create diagrams.
 Ideally you would "animate" those diagrams by creating multiple incremental versions of the diagram and adding each to a slide;
 when browsing slides pieces of these diagrams will "appear" and complete the final image, rendering an animation-like effect.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,10 @@ They consider contributions to both actual content (mostly Markdown) and support
 ## First Steps
 
 Some good first steps and best practices when using Git are explained here:
-* the Git Immersion tutorial: https://gitimmersion.com/
-* the Atlassian tutorial: https://www.atlassian.com/git/tutorials/learn-git-with-bitbucket-cloud
-* this blog post on the ROSEdu Techblog: https://techblog.rosedu.org/git-good-practices.html
+
+* the Git Immersion tutorial: <https://gitimmersion.com/>
+* the Atlassian tutorial: <https://www.atlassian.com/git/tutorials/learn-git-with-bitbucket-cloud>
+* this blog post on the ROSEdu Techblog: <https://techblog.rosedu.org/git-good-practices.html>
 
 ## Language
 
@@ -66,6 +67,6 @@ Also make sure one pull request covers only **one** topic.
 
 Use commit messages with verbs at imperative mood: "Add README", "Update contents", "Introduce feature".
 Prefix each commit message with the chapter it belongs to: `software-stack`, `data`, `compute`, `io`, `app-interact`.
-How a good commit message should look like: https://cbea.ms/git-commit/
+How a good commit message should look like: <https://cbea.ms/git-commit/>
 
 The use of `-s` / `--signoff` when creating a commit is optional, but strongly recommended.

--- a/COPYING.md
+++ b/COPYING.md
@@ -7,7 +7,7 @@ A copy of each license is below.
 
 Copy of CC BY-SA 4.0:
 
-```
+```text
 Attribution-NonCommercial-ShareAlike 4.0 International
 
 =======================================================================
@@ -449,7 +449,7 @@ Creative Commons may be contacted at creativecommons.org.
 
 Copy of BSD-3-Clause:
 
-```
+```text
 Copyright 2021 University POLITEHNICA of Bucharest
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It currently consists of 5 chapters:
 
 Each chapter has its own folder.
 Content for each chapter is split in two subfolders:
+
 * `lecture/`: content to be presented and discussed as part of lectures
 * `lab/`: content to be worked on as practical activities during labs / seminars
 

--- a/content/chapters/compute/lab/content/arena.md
+++ b/content/chapters/compute/lab/content/arena.md
@@ -65,7 +65,7 @@ Its main purpose is to determine the way in which child processes interact with 
 Now let's test this flag, as well as its opposite: `MAP_SHARED`.
 Compile and run the code in `support/shared-memory/shared_memory.c`.
 
-1. See the value read by the parent id different from that written by the child.
+1. See the value read by the parent is different from that written by the child.
 Modify the `flags` parameter of `mmap()` so they are the same.
 
 1. Create a semaphore in the shared page and use it to make the parent signal the child before it can exit.

--- a/content/chapters/compute/lab/content/arena.md
+++ b/content/chapters/compute/lab/content/arena.md
@@ -7,7 +7,7 @@ We'll see that in order to create both threads and processes, the underlying Lin
 For this, we'll run both `sum_array_threads` and `sum_array_processes` under `strace`.
 As we've already established, we're only interested in the `clone` syscall:
 
-```
+```console
 student@os:~/.../lab/support/sum-array/d$ strace -e clone ./sum_array_threads 2
 clone(child_stack=0x7f60b56482b0, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, parent_tid=[1819693], tls=0x7f60b5649640, child_tidptr=0x7f60b5649910) = 1819693
 clone(child_stack=0x7f60b4e472b0, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, parent_tid=[1819694], tls=0x7f60b4e48640, child_tidptr=0x7f60b4e48910) = 1819694
@@ -20,6 +20,7 @@ clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, c
 We ran each program with an argument of 2, so we have 2 calls to `clone`.
 Notice that in the case of threads, the `clone` syscall receives more arguments.
 The relevant flags passed as arguments when creating threads are documented in [`clone`'s man page](https://man.archlinux.org/man/clone3.2.en):
+
 - `CLONE_VM`: the child and the parent process share the same VAS
 - `CLONE_{FS,FILES,SIGHAND}`: the new thread shares the filesystem information, file and signal handlers with the one that created it
 The syscall also receives valid pointers to the new thread's stack and TLS, i.e. the only parts of the VAS that are distinct between threads (although they are technically accessible from all threads).
@@ -67,7 +68,7 @@ Compile and run the code in `support/shared-memory/shared_memory.c`.
 1. See the value read by the parent id different from that written by the child.
 Modify the `flags` parameter of `mmap()` so they are the same.
 
-2. Create a semaphore in the shared page and use it to make the parent signal the child before it can exit.
+1. Create a semaphore in the shared page and use it to make the parent signal the child before it can exit.
 Use the API defined in [`semaphore.h`](https://man7.org/linux/man-pages/man0/semaphore.h.0p.html).
 **Be careful!**
 The value written and read previously by the child and the parent, respectively, must not change.
@@ -87,7 +88,7 @@ Let's see how and why.
 First, we run the following command to trace the `execve()` syscalls used by `sleepy_creator`.
 We'll leave `fork()` for later.
 
-```
+```console
 student@os:~/.../support/sleepy$ strace -e execve -ff -o syscalls ./sleepy_creator
 ```
 
@@ -98,7 +99,7 @@ the other logs those two syscalls when made by the child process.
 Let's take a look at them.
 The numbers below will differ from those on your system:
 
-```
+```console
 student@os:~/.../support/sleepy:$ cat syscalls.2523393  # syscalls from parent process
 execve("sleepy_creator", ["sleepy_creator"], 0x7ffd2c157758 /* 39 vars */) = 0
 --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=2523394, si_uid=1052093, si_status=0, si_utime=0, si_stime=0} ---
@@ -128,10 +129,11 @@ Find a way to do this.
 
 > **Hint**:  You can see what `sleepy` does and draw inspiration from there.
 > Use `strace` to also list the calls to `clone()` perfromed by `sleepy` or its children.
-> [Remember](#threads-and-processes-clone) what `clone()` is used for and use its parameters to deduce which of the two scenarios happens to `sleepy`. 
+> [Remember](#threads-and-processes-clone) what `clone()` is used for and use its parameters to deduce which of the two scenarios happens to `sleepy`.
 
 **Moral of the story**: We can add another step to the moral of [our previous story](./processes.md#practice-fork).
 When spawning a new command, the call order is:
+
 - parent: `fork()`, `exec()`, `wait()`
 - child: `exit()`
 
@@ -191,7 +193,7 @@ Single-threadedness is a common trope for interpreted languages to use some sort
 [Ruby MRI, the reference Ruby interpreter](https://git.ruby-lang.org/ruby.git) uses a similar mechanism, called the [Global VM Lock](https://ivoanjo.me/blog/2022/07/17/tracing-ruby-global-vm-lock/).
 JavaScript is even more straightforward: it is single-threaded by design, also for GC-related reasons.
 It does, however support asynchronous actions, but these are executed on the same thread as every other code.
-This is implemented by placing each instruction on a [call stack](https://medium.com/swlh/what-does-it-mean-by-javascript-is-single-threaded-language-f4130645d8a9). 
+This is implemented by placing each instruction on a [call stack](https://medium.com/swlh/what-does-it-mean-by-javascript-is-single-threaded-language-f4130645d8a9).
 
 ### Atomic Assembly
 

--- a/content/chapters/compute/lab/content/benchmarks.md
+++ b/content/chapters/compute/lab/content/benchmarks.md
@@ -4,6 +4,7 @@ The main criterion we use to rank CPUs is their _computation power_, i.e. their 
 Numerous benchmarks exist out there and they are publicly displayed on sites such as [CPUBenchmark](https://www.cpubenchmark.net/).
 
 This benchmark measures the performance of the computer's CPU in a variety of scenarios:
+
 - its ability to perform integer operations
 - its speed in floating point arithmetic
 - data encryption and compression

--- a/content/chapters/compute/lab/content/copy-on-write.md
+++ b/content/chapters/compute/lab/content/copy-on-write.md
@@ -33,7 +33,7 @@ Remember from the [Data chapter](../../../data/) that **demand paging** means th
 On the other hand, **copy-on-write** posits that the virtual memory is already mapped to some frames.
 These frames are only duplicated when one of the processes attempts to write data to them.
 
-#### Practice
+### Practice
 
 Now let's see the copy-on-write mechanism in practice.
 Keep in mind that `fork()` is a function used to create a process.
@@ -42,7 +42,7 @@ Open two terminals (or better: use [`tmux`](https://github.com/tmux/tmux/wiki)).
 In one of them compile and run the code in `support/fork-faults/fork_faults.c`.
 After each time you press `Enter` in the first terminal window, run the following command in the second window:
 
-```
+```console
 student@os:~/.../lab/support/fork-faults$ ps -o min_flt,maj_flt -p $(pidof fork_faults)
 ```
 

--- a/content/chapters/compute/lab/content/processes-threads-apache2.md
+++ b/content/chapters/compute/lab/content/processes-threads-apache2.md
@@ -9,6 +9,7 @@ Instead, `apache2` provides a couple of modules called MPMs (Multi-Processing Mo
 Each module implements a different concurrency model and the users can pick whatever module best fits their needs by editing the server configuration files.
 
 The most common MPMs are
+
 - `prefork`: there are multiple worker processes, each process is single-threaded and handles one client request at a time
 - `worker`: there are multiple worker processes, each process is multi-threaded, and each thread handles one client request at a time
 - `event`: same as `worker` but designed to better handle some particular use cases
@@ -25,14 +26,14 @@ This will start a container with `apache2` running inside.
 
 Check that the server runs as expected:
 
-```
+```console
 student@os:~$ curl localhost:8080
 <html><body><h1>It works!</h1></body></html>
 ```
 
 Now go inside the container and take a look at running processes:
 
-```
+```console
 student@os:~/.../lab/support/apache2$ docker exec -it apache2-test bash
 
 root@56b9a761d598:/usr/local/apache2# ps -ef
@@ -49,7 +50,7 @@ The first one, running as root, is the main process, while the other 2 are the w
 
 Let's confirm that we are using the `event` mpm:
 
-```
+```console
 root@56b9a761d598:/usr/local/apache2# grep mod_mpm conf/httpd.conf
 LoadModule mpm_event_module modules/mod_mpm_event.so
 #LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -59,7 +60,7 @@ LoadModule mpm_event_module modules/mod_mpm_event.so
 The `event` mpm is enabled, so we expect each worker to be multi-threaded.
 Let's check:
 
-```
+```console
 root@56b9a761d598:/usr/local/apache2# ps -efL
 UID          PID    PPID     LWP  C NLWP STIME TTY          TIME CMD
 root           1       0       1  0    1 20:56 pts/0    00:00:00 httpd -DFOREGROUND
@@ -91,7 +92,7 @@ Let's see this dynamic scaling in action.
 We need to create a number of simultaneous connections that is larger than the current number of threads.
 There is a simple script in `support/apache2/make_conn.py` to do this:
 
-```
+```console
 student@os:~/.../lab/support/apache2$ python3 make_conn.py localhost 8080
 Press ENTER to exit
 ```
@@ -100,7 +101,7 @@ The script has created 100 connections and will keep them open until we press En
 
 Now, in another terminal, let's check the situation inside the container:
 
-```
+```console
 student@os:~/.../lab/support/apache2$ docker exec -it apache2-test bash
 
 root@56b9a761d598:/usr/local/apache2# ps -efL

--- a/content/chapters/compute/lab/content/processes.md
+++ b/content/chapters/compute/lab/content/processes.md
@@ -5,7 +5,7 @@ Let's take the `ls` command as a trivial example.
 `ls` is a **program** on your system.
 It has a binary file which you can find and inspect with the help of the `which` command:
 
-```
+```console
 student@os:~$ which ls
 /usr/bin/ls
 
@@ -17,7 +17,7 @@ When you run it, the `ls` binary stored **on the disk** at `/usr/bin/ls` is read
 The loader spawns a **process** by copying some of the contents `/usr/bin/ls` in memory (such as the `.text`, `.rodata` and `.data` sections).
 Using `strace`, we can see the [`execve`](https://man7.org/linux/man-pages/man2/execve.2.html) system call:
 
-```
+```console
 student@os:~$ strace -s 100 ls -a  # -s 100 limits strings to 100 bytes instead of the default 32
 execve("/usr/bin/ls", ["ls", "-a"], 0x7fffa7e0d008 /* 61 vars */) = 0
 [...]
@@ -28,7 +28,9 @@ close(2)                                = 0
 exit_group(0)                           = ?
 +++ exited with 0 +++
 ```
+
 Look at its parameters:
+
 - the path to the **program**: `/usr/bin/ls`
 - the list of arguments: `"ls", "-a"`
 - the environment variables: the rest of the syscall's arguments
@@ -47,7 +49,7 @@ It would probabily look like the code in `support/sum-array/d/sum_array_sequenti
 The program also measures the time spent computing the sum.
 Let's compile and run it:
 
-```
+```console
 student@os:~/.../lab/support/sum-array/d$ ./sum_array_sequential
 Array sum is: 49945994146
 Time spent: 127 ms
@@ -63,10 +65,11 @@ Due to how it's implemented so far, our program only uses one of our CPU's cores
 We never tell it to distribute its workload on other cores.
 This is wasteful as the rest of our cores remain unused:
 
-```
+```console
 student@os:~$ lscpu | grep ^CPU\(s\):
 CPU(s):                          8
 ```
+
 We have 7 more cores waiting to add numbers in our array.
 
 ![What if we used 100% of the CPU?](../media/100-percent-cpu.jpeg)
@@ -119,7 +122,7 @@ Now use `pstree -pac` and look for the `sleep` processes you have just created.
 
 [Quiz](../quiz/parent-of-sleep-processes.md)
 
-2. Change the code in `sleepy_creator.py` so that the `sleep 1000` processes are the children of `sleepy_creator.py`.
+1. Change the code in `sleepy_creator.py` so that the `sleep 1000` processes are the children of `sleepy_creator.py`.
 Kill the previously created `sleep` processes using `killall sleep`.
 Verify that `sleepy_creator.py` remains the parent of the `sleep`s it creates using `pstree -pac`.
 
@@ -136,7 +139,7 @@ Go to `support/sleepy/sleepy_creator.c` and use [`system`](https://man7.org/linu
 The `man` page also mentions that `system` calls `fork()` and `exec()` to run the command it's given.
 If you want to find out more about them, head over to the [Arena and create your own mini-shell](./arena.md#mini-shell).
 
-#### Practice: Wait for Me!
+#### Practice: Wait for Me
 
 Run the code in `support/wait-for-me/wait_for_me_processes.py`.
 The parent process creates one child that writes and message to the given file.
@@ -167,6 +170,7 @@ Now we will move one step lower on the call stack and call `fork()` ourselves.
 We say that `fork()` returns **twice**: once in the parent process and once more in the child process.
 This means that after `fork()` returns, assuming no error has occurred, both the child and the parent resume execution from the same place: the instruction following the call to `fork()`.
 What's different between the two processes is the value returned by `fork()`:
+
 - **child process**: `fork()` returns 0
 - **parent process**: `fork()` returns the PID of the child process (> 0)
 - **on error**: `fork()` returns -1, only once, in the initial process
@@ -174,10 +178,11 @@ What's different between the two processes is the value returned by `fork()`:
 Therefore, the typical code for handling a `fork()` is available in `support/create-process/fork.c`.
 Take a look at it and then run it.
 Notice what each of the two processes prints:
+
 - the PID of the child is also known by the parent
 - the PPID of the child is the PID of the parent
 
-Unlike `system()`, who also waits for its child, when using `fork()` we must do the waiting ourselves. 
+Unlike `system()`, who also waits for its child, when using `fork()` we must do the waiting ourselves.
 In order to wait for a process to end, we use the [`waitpid()`](https://linux.die.net/man/2/waitpid) syscall.
 It places the exit code of the child process in the `status` parameter.
 This argument is actually a bitfield containing more information that merely the exit code.
@@ -190,7 +195,7 @@ Now modify the example to do the following:
 
 1. Change the return value of the child process so that the value displayed by the parent is changed.
 
-2. Create a child process of the newly created child.
+1. Create a child process of the newly created child.
 Use a similar logic and a similar set of prints to those in the support code.
 Take a look at the printed PIDs.
 Make sure the PPID of the "grandchild" is the PID of the child, whose PPID is, in turn, the PID of the parent.

--- a/content/chapters/compute/lab/content/scheduling.md
+++ b/content/chapters/compute/lab/content/scheduling.md
@@ -64,15 +64,11 @@ When a thread ends its execution, it is added to the COMPLETED queue, together w
 
 ### Thread Control Block
 
-<!-- markdownlint-disable MD051 -->
-
 Let's dissect the `threads_create()` function a bit.
 It first initialises its queues and the timer for preemption.
-We'll discuss preemption [in the next section](#preemption).
+We'll discuss preemption [in the next section](#scheduling---how-is-it-done).
 After performing initialisations, the function creates a `TCB` object.
 TCB stands for **Thread Control Block**.
-
-<!-- markdownlint-enable MD051 -->
 
 During the [lecture](../../lecture/), you saw that the kernel stores one instance of a [`task_struct`](https://elixir.bootlin.com/linux/v5.19.11/source/include/linux/sched.h#L726) for each thread.
 Remember that its most important fields are:
@@ -183,12 +179,8 @@ If you encounter the following error when running `test_ult`, remember what you 
 
 > Hint: Use the `LD_LIBRARY_PATH` variable.
 
-<!-- markdownlint-disable MD051 -->
-
 Notice that the threads run their code and alternatively, because their prints appear interleaved.
-[In the next section](#preemption), we'll see how this is done.
-
-<!-- markdownlint-enable MD051 -->
+[In the next section](#scheduling---how-is-it-done), we'll see how this is done.
 
 [Quiz](../quiz/ult-thread-ids.md)
 

--- a/content/chapters/compute/lab/content/scheduling.md
+++ b/content/chapters/compute/lab/content/scheduling.md
@@ -1,7 +1,7 @@
 ## Scheduling
 
-- https://github.com/kissen/threads
-- https://www.schaertl.me/posts/a-bare-bones-user-level-thread-library/
+- <https://github.com/kissen/threads>
+- <https://www.schaertl.me/posts/a-bare-bones-user-level-thread-library/>
 
 Up to now we know that the OS decides which **thread** (not process) runs on each CPU core at each time.
 Now we'll learn about the component that performs this task specifically: **the scheduler**.
@@ -16,6 +16,7 @@ To do this, the scheduler must decide, at given times, to suspend a thread, save
 This event is called a **context switch**.
 A context switch means changing the state of one thread (the replaced thread) from RUNNING to WAITING and the state of the replacement thread from READY / WAITING to RUNNING.
 
+<!-- TODO -->
 - Quiz?
 
 ### User-Level vs Kernel-Level Threads
@@ -25,7 +26,7 @@ The threads you've used so far are **kernel-level threads (KLT)**.
 They are created and scheduled in the kernel of the OS.
 One of the most important of their features is that they offer true parallelism.
 With KLTs, we can truly run a program on all the cores of our CPU at once.
-But we must pay a price for this: scheduling them is very complex and context switches are costly (in terms of time), especially when switching threads belonging to different processes. 
+But we must pay a price for this: scheduling them is very complex and context switches are costly (in terms of time), especially when switching threads belonging to different processes.
 
 By contrast, **user-level threads (ULT)** are managed by the user space.
 More of the ULTs created by a program are generally mapped to the same kernel thread.
@@ -63,11 +64,15 @@ When a thread ends its execution, it is added to the COMPLETED queue, together w
 
 ### Thread Control Block
 
+<!-- markdownlint-disable MD051 -->
+
 Let's dissect the `threads_create()` function a bit.
 It first initialises its queues and the timer for preemption.
 We'll discuss preemption [in the next section](#preemption).
 After performing initialisations, the function creates a `TCB` object.
 TCB stands for **Thread Control Block**.
+
+<!-- markdownlint-enable MD051 -->
 
 During the [lecture](../../lecture/), you saw that the kernel stores one instance of a [`task_struct`](https://elixir.bootlin.com/linux/v5.19.11/source/include/linux/sched.h#L726) for each thread.
 Remember that its most important fields are:
@@ -155,7 +160,7 @@ There are some visible similarities between the two TCBs.
 
 Therefore, the workflow for creating and running a thread goes like this:
 
-```
+```console
 main thread
     |
     `--> threads_create()
@@ -172,14 +177,18 @@ main thread
 Compile and run the code in `support/libult/test_ult.c`.
 If you encounter the following error when running `test_ult`, remember what you learned about the loader and using custom shared libraries in the [Software Stack lab](../../software-stack/lab).
 
-```
+```console
 ./test_ult: error while loading shared libraries: libult.so: cannot open shared object file: No such file or directory
 ```
 
 > Hint: Use the `LD_LIBRARY_PATH` variable.
 
+<!-- markdownlint-disable MD051 -->
+
 Notice that the threads run their code and alternatively, because their prints appear interleaved.
 [In the next section](#preemption), we'll see how this is done.
+
+<!-- markdownlint-enable MD051 -->
 
 [Quiz](../quiz/ult-thread-ids.md)
 
@@ -207,7 +216,6 @@ This increases its complexity and the duration of context switches, but threads 
 Preemptive schedulers assign only allow threads to run for a maximum amount of time, called **time slice** (usually a few milliseconds).
 They use timers which fire when a new time slice passes.
 The firing of one such timer causes a context switch whereby the currently RUNNING thread is _preempted_ (i.e. suspended) and replaced with another one.
-
 
 [Quiz](../quiz/type-of-scheduler-in-libult.md)
 
@@ -259,6 +267,6 @@ This is how scheduling is done!
 Re-run the code in `support/libult/test_ult.c`.
 Notice that now no context switch happens between the 2 created threads because they end before the timer can fire.
 
-2. Now change the `printer_thread()` function in `test_ult.c` to make it run for more than 2 seconds.
+1. Now change the `printer_thread()` function in `test_ult.c` to make it run for more than 2 seconds.
 See that now the prints from the two threads appear intermingled.
 Add prints to the `handle_sigprof()` function in `support/libult/threads.c` to see the context switch happen.

--- a/content/chapters/compute/lab/content/synchronization.md
+++ b/content/chapters/compute/lab/content/synchronization.md
@@ -56,7 +56,7 @@ When calling `unlock()`, the internal variable is set to 0 and all waiting threa
 **Be careful:** It is generally considered unsafe and [in many cases undefined behaviour](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_lock.html) to call `unlock()` from a different thread than the one that acquired the lock.
 So the general workflow should look something like this:
 
-```
+```text
 within a single thread:
     mutex.lock()
     // do atomic stuff
@@ -98,7 +98,7 @@ Modern processors are capable of _atomically_ accessing data, either for reads o
 An atomic action is and indivisible sequence of operations that a thread runs without interference from others.
 Concretely, before initiating an atomic transfer on one of its data buses, the CPU first makes sure all other transfers have ended, then **locks** the data bus by stalling all cores attempting to transfer data on it.
 This way, one thread obtains **exclusive** access to the data bus while accessing data.
-As a side note, the critical sections in `support/race-condition/race_condition_mutex.d` are also atomic once they are wrapped between calls to `lock()` and `unlock()`. 
+As a side note, the critical sections in `support/race-condition/race_condition_mutex.d` are also atomic once they are wrapped between calls to `lock()` and `unlock()`.
 
 As with every hardware feature, the x86 ISA exposes an instruction for atomic operations.
 In particular this instruction is a **prefix**, called `lock`.
@@ -262,7 +262,7 @@ Try to compile the code.
 It fails.
 The compiler is smart and tells you what to do instead:
 
-```
+```console
 Error: read-modify-write operations are not allowed for `shared` variables
         Use `core.atomic.atomicOp!"+="(var, 1)` instead
 ```
@@ -287,9 +287,9 @@ You should see that in the end, `var` is 0.
 
 [Quiz 2](../quiz/tls-var-copies.md)
 
-2. Print the address and value of `var` in each thread.
+1. Print the address and value of `var` in each thread.
 See that they differ.
 
-3. Modify the value of `var` in the `main()` function before calling `pthread_create()`.
+1. Modify the value of `var` in the `main()` function before calling `pthread_create()`.
 Notice that the value doesn't propagate to the other threads.
-This is because, upon creating a new thread, its TLS is initialised. 
+This is because, upon creating a new thread, its TLS is initialised.

--- a/content/chapters/compute/lab/content/threads.md
+++ b/content/chapters/compute/lab/content/threads.md
@@ -10,7 +10,7 @@ Because a process needs a separate virtual address space (VAS) and needs to dupl
 On the other hand, threads belonging to the same process share the same VAS and, implicitly, the same OS-internal structures.
 Therefore, they are more lightweight than processes.
 
-#### Practice: Wait for Me Once More!
+#### Practice: Wait for Me Once More
 
 Go to `support/wait-for-me/wait_for_me_threads.d`.
 Spawn a thread that executes the `negateArray()` function.
@@ -46,7 +46,7 @@ Therefore, when we split our workload between several threads and one of them ca
 The same thing happens when we use processes instead of threads: one process causes an error, which gets it killed, but the other processes continue their work unhindered.
 This is why we end up with a lower sum in the end: because one process died too early and didn't manage to write the partial sum it had computed to the `results` array.
 
-#### Practice: Wait for It!
+#### Practice: Wait for It
 
 The process that spawns all the others and subsequently calls `waitpid` to wait for them to finish can also get their return codes.
 Update the code in `support/sum-array-bugs/seg-fault/sum_array_processes.d` and modify the call to `waitpid` to obtain and investigate this return code.
@@ -56,7 +56,7 @@ Remember to use the appropriate [macros](https://linux.die.net/man/2/waitpid) fo
 When a process runs into a system error, it receives a signal.
 A signal is a means to interrupt the normal execution of a program from the outside.
 It is associated with a number.
-Use `kill -l` to find the full list of signals. 
+Use `kill -l` to find the full list of signals.
 
 [Quiz](../quiz/seg-fault-exit-code.md)
 
@@ -74,7 +74,7 @@ One uses threads while the other uses processes.
 Run both programs with and without memory corruption.
 Pass any value as a third argument to trigger the corruption.
 
-```
+```console
 student@os:~/.../sum-array-bugs/memory-corruption/python$ python3 memory_corruption_processes.py <number_of_processes>  # no memory corruption
 [...]
 

--- a/content/chapters/compute/lab/content/threads.md
+++ b/content/chapters/compute/lab/content/threads.md
@@ -14,7 +14,8 @@ Therefore, they are more lightweight than processes.
 
 Go to `support/wait-for-me/wait_for_me_threads.d`.
 Spawn a thread that executes the `negateArray()` function.
-For now, do not wait for it to finish; simply start it.
+For now, do not wait for it to finish;
+simply start it.
 
 Compile the code and run the resulting executable several times.
 See that the negative numbers appear from different indices.

--- a/content/chapters/compute/lab/quiz/apache2-strace.md
+++ b/content/chapters/compute/lab/quiz/apache2-strace.md
@@ -7,8 +7,11 @@ What is the document root of the `apache2` server?
 ## Question Answers
 
 - `/etc/apache2`
+
 + `/usr/local/apache2/htdocs/`
+
 - `/var/www/html`
+
 - `/var/www/apache2/htdocs`
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/cause-of-file-not-found-error.md
+++ b/content/chapters/compute/lab/quiz/cause-of-file-not-found-error.md
@@ -7,8 +7,11 @@ What causes the `FileNotFoundError` when running `support/wait-for-me/wait_for_m
 ## Question Answers
 
 + The parent process attempts to open the file before the child process has had the time to create it
+
 - There is a syntax error in the Python code
+
 - The mode with which to open the file is not specified in the parent process
+
 - The child process doesn't close the file
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/child-faults-after-write.md
+++ b/content/chapters/compute/lab/quiz/child-faults-after-write.md
@@ -7,7 +7,11 @@ What causes the page faults registered by the child after the fifth step?
 ## Question Answers
 
 + The child writes data to the frames it previously shared with its parent and the copy-on-write mechanism copies and remaps them before writing said data
+
 - Demand paging propagates the lazy allocation of pages from the parent to the child
+
 - Creating the child process inherently duplicates some frames
+
 - They are caused by the loader forking itself when creating the child process
+
 - They are caused by the `bash` process forking itself when creating the child process

--- a/content/chapters/compute/lab/quiz/coarse-vs-granular-critical-section.md
+++ b/content/chapters/compute/lab/quiz/coarse-vs-granular-critical-section.md
@@ -7,7 +7,9 @@ Why does code with the the larger (coarser) critical section run faster than the
 ## Question Answers
 
 + Because the more granular code causes more context switches, which are expensive
+
 - Because the coarser code can be better optimised by the compiler
+
 - Because the loops in the more granular code run for more steps
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/create-sleepy-process-ending.md
+++ b/content/chapters/compute/lab/quiz/create-sleepy-process-ending.md
@@ -8,14 +8,19 @@ Use [`system`'s man page](https://man7.org/linux/man-pages/man3/system.3.html) t
 ## Question Answers
 
 - Because the code is unoptimised (the default optimisation level is `-O0`)
+
 - Because the operating system takes very long to finish the process
+
 + Because `system` returns when the command given to it (`sleep 1000`) ends
+
 - Because the CPU is very slow
 
 ## Feedback
 
 The [man page](https://man7.org/linux/man-pages/man3/system.3.html) says it clearly:
-```
+
+```text
 system() returns after the command has been completed.
 ```
+
 Therefore, in our case, it returns after `sleep 1000` ends.

--- a/content/chapters/compute/lab/quiz/mini-shell-stops-after-command.md
+++ b/content/chapters/compute/lab/quiz/mini-shell-stops-after-command.md
@@ -7,8 +7,11 @@ Why does the `mini_shell` process stop after executing a single command?
 ## Question Answers
 
 - Because of an implementation error
+
 + Because the `mini_shell` process doesn't exist anymore
+
 - Because the OS sees that the command has ended and ends the `mini_shell` process as well
+
 - Because `exec*()` syscalls also kill the caller process when the callee ends
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/mmap-cow-flag.md
+++ b/content/chapters/compute/lab/quiz/mmap-cow-flag.md
@@ -7,15 +7,18 @@ From the description in its [man page](https://man7.org/linux/man-pages/man2/mma
 ## Question Answers
 
 - `MAP_SHARED`
+
 + `MAP_PRIVATE`
+
 - `MAP_ANONYMOUS`
+
 - `MAP_POPULATE`
 
 ## Feedback
 
 Quoting the [man page](https://man7.org/linux/man-pages/man2/mmap.2.html):
 
-```
+```text
 MAP_PRIVATE
               Create a private copy-on-write mapping.
 ```

--- a/content/chapters/compute/lab/quiz/notify-only-with-mutex.md
+++ b/content/chapters/compute/lab/quiz/notify-only-with-mutex.md
@@ -7,9 +7,12 @@ Can we only use a mutex when signalling an event from one thread to another in?
 ## Question Answers
 
 + No, because this would imply that the signalling thread would `unlock()` the mutex, that the signalled thread attempts to `lock()`, which is an undefined behaviour
+
 - No, because it will result in a deadlock where the both threads will be waiting for each other
+
 - Yes, because only one thread can modify the shared variables in order to maintain their integrity
-- Yes and this would yield better performance because the threads would only wait for one object: the mutex 
+
+- Yes and this would yield better performance because the threads would only wait for one object: the mutex
 
 ## Feedback
 

--- a/content/chapters/compute/lab/quiz/number-of-running-ults.md
+++ b/content/chapters/compute/lab/quiz/number-of-running-ults.md
@@ -2,13 +2,16 @@
 
 ## Question Text
 
-How many threads can be RUNNING simultaneously if we only create them using the API exposed by `libult.so`? 
+How many threads can be RUNNING simultaneously if we only create them using the API exposed by `libult.so`?
 
 ## Question Answers
 
 - Equal to the number of cores on the CPU
+
 + 1
+
 - None
+
 - 2: the main thread and another one for the created threads
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/parent-faults-before-fork.md
+++ b/content/chapters/compute/lab/quiz/parent-faults-before-fork.md
@@ -7,6 +7,9 @@ What causes the page faults that occur between the first and second steps?
 ## Question Answers
 
 - Calling `fork()` duplicates the pages previously allocated by the parent
-+ Demand paging makes the pages in the `p` array to be mapped to frames only when written.
+
++ Demand paging makes the pages in the `p` array to be mapped to frames only when written
+
 - The OS duplicates the parent's pages in preparation for `fork()`
+
 - `mmap()` sets the pages to be mapped at a later time, decided by the OS

--- a/content/chapters/compute/lab/quiz/parent-of-sleep-processes.md
+++ b/content/chapters/compute/lab/quiz/parent-of-sleep-processes.md
@@ -2,7 +2,8 @@
 
 ## Question Text
 
-Who is the parent of the `sleep` processes? Why?
+Who is the parent of the `sleep` processes?
+Why?
 
 ## Question Answers
 

--- a/content/chapters/compute/lab/quiz/parent-of-sleep-processes.md
+++ b/content/chapters/compute/lab/quiz/parent-of-sleep-processes.md
@@ -7,8 +7,11 @@ Who is the parent of the `sleep` processes? Why?
 ## Question Answers
 
 - `sleepy_creator.py` because it is the one who created them
-- `bash` because it is `sleepy_creator.py`'s parent and when a process dies, its parent adopts its orphan children 
+
+- `bash` because it is `sleepy_creator.py`'s parent and when a process dies, its parent adopts its orphan children
+
 + `systemd` because this is the default process that adopts orphans
+
 - `systemd` because it is `sleepy_creator.py`'s parent and when a process dies, its parent adopts its orphan children
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/processes-speedup.md
+++ b/content/chapters/compute/lab/quiz/processes-speedup.md
@@ -7,8 +7,11 @@ Why is the speedup from running the program in `support/sum-array/d/sum_array_pr
 ## Question Answers
 
 - Because the array is split into unequal parts
+
 + Because of the overhead introduced by the creation of the additional processes
+
 - Because the algorithm is incorrect
+
 - Because the operating systems runs all processes sequentially on the same core
 
 ## Feedback
@@ -18,7 +21,7 @@ The OS calls the loader, launches the new process, then the parent process waits
 All this work together with creating the initial process has to be done by a single thread.
 In addition, in real-world apps, other actions such as receiving data from the network or reading a file are inherently **sequential**.
 Therefore there will always be parts of any given program that cannot be run in parallel.
-As a result, the speedup can never be equal to the number of processes between which we spread the workload. 
+As a result, the speedup can never be equal to the number of processes between which we spread the workload.
 
 It is possible to compute the speedup obtained from parallelising a portion of a given program.
 The formula is rather simple and is called [Amdahl's law](https://en.wikipedia.org/wiki/Amdahl%27s_law)

--- a/content/chapters/compute/lab/quiz/seg-fault-exit-code.md
+++ b/content/chapters/compute/lab/quiz/seg-fault-exit-code.md
@@ -7,8 +7,11 @@ What is the exit code of the faulty child process spawned by `support/sum-array-
 ## Question Answers
 
 + 11 because this is the code of the `SIGSEGV` signal
+
 - 11 because this code is always returned when a process ends with an error
+
 - 11 because this is the value of the least significant 4 bytes of the partial array sum calculated by the process
+
 - 6 because the child process was aborted
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/semaphore-equivalent.md
+++ b/content/chapters/compute/lab/quiz/semaphore-equivalent.md
@@ -7,8 +7,11 @@ From running and inspecting the code in `support/apache2-simulator/apache2_simul
 ## Question Answers
 
 - The value of `msg_mutex`
+
 - The time a worker thread has to wait before running
+
 + The length of the `messages` list
+
 - The number of worker threads
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/tcb-libult-unikraft.md
+++ b/content/chapters/compute/lab/quiz/tcb-libult-unikraft.md
@@ -7,14 +7,23 @@ Which members of the TCBs in `libult` and Unikraft have similar meanings?
 ## Question Answers
 
 + `start_routine` and `entry`
+
 - `id` and `name`
+
 + `context.uc_stack` and `stack`
+
 - `arguments` and `flags`
+
 - `has_dynamic_stack` and `detached`
+
 + `argument` and `arg`
+
 - `context` and `sched`
+
 - `context` and `tls`
+
 + `context` and `ctx`
+
 + `return_value` and `prv`
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/time-slice-value.md
+++ b/content/chapters/compute/lab/quiz/time-slice-value.md
@@ -7,8 +7,11 @@ Using the [man page](https://man7.org/linux/man-pages/man2/setitimer.2.html), wh
 ## Question Answers
 
 - 100 milliseconds
+
 - 10 microseconds
+
 - 100 microseconds
+
 + 10 milliseconds
 
 ## Feedback
@@ -35,5 +38,5 @@ struct timeval {
 	suseconds_t tv_usec;        /* microseconds */
 };
 ```
-So when constructing the `timer` variable, `{ 0, 10000 }` means 0 seconds and 10000 microseconds, i.e. 0 seconds and 10 milliseconds. 
 
+So when constructing the `timer` variable, `{ 0, 10000 }` means 0 seconds and 10000 microseconds, i.e. 0 seconds and 10 milliseconds.

--- a/content/chapters/compute/lab/quiz/tls-synchronization.md
+++ b/content/chapters/compute/lab/quiz/tls-synchronization.md
@@ -8,9 +8,12 @@ Is placing `var` from `support/race-condition/c/race_condition_tls.c` in the TLS
 
 - No, because the race condition remains.
 It just doesn't manifest itself anymore
-+ No, because the threads now access different variables, not the same one.
+
++ No, because the threads now access different variables, not the same one
+
 - Yes, because we now remove the race condition
-- Yes, because now the result is correct.
+
+- Yes, because now the result is correct
 
 ## Feedback
 

--- a/content/chapters/compute/lab/quiz/tls-var-copies.md
+++ b/content/chapters/compute/lab/quiz/tls-var-copies.md
@@ -7,10 +7,13 @@ How many copies of the `var` variable from `support/race-condition/c/race_condit
 ## Question Answers
 
 - 1
+
 - 2
+
 + 3
+
 - 5
 
 ## Feedback
 
-There are 3 copies one for the `main()` thread, another one for `increment_var()` and the third for `decrement_var()`. 
+There are 3 copies one for the `main()` thread, another one for `increment_var()` and the third for `decrement_var()`.

--- a/content/chapters/compute/lab/quiz/type-of-scheduler-in-libult.md
+++ b/content/chapters/compute/lab/quiz/type-of-scheduler-in-libult.md
@@ -8,7 +8,9 @@ Which type of scheduler does `libult.so` use?
 ## Question Answers
 
 + It uses a preemptive scheduler
+
 - It uses a cooperative scheduler
+
 - It uses both a cooperative and a preemptive scheduler
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/ult-thread-ids.md
+++ b/content/chapters/compute/lab/quiz/ult-thread-ids.md
@@ -9,10 +9,13 @@ Why is this necessary.
 
 - Because ID 1 is associated with the main thread.
 This is an implementation detail and can be omitted.
+
 + Because ID 1 belongs to the main thread.
 This is needed in order to associate a `ucontext_t` with the main thread as well, so the main thread can also be run.
+
 - Because the underlying kernel thread is assigned ID 1.
 This is mandatory in order for the OS's scheduler to run this thread.
+
 - Because `libult.so` first creates a pool of threads from which it `threads_create()` retrieves the threads it returns.
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/who-calls-execve-parent.md
+++ b/content/chapters/compute/lab/quiz/who-calls-execve-parent.md
@@ -7,8 +7,11 @@ Which process calls `execve("sleepy_creator", ["sleepy_creator"], ...)`, that yo
 ## Question Answers
 
 - The kernel because that's where the loader is located
+
 - The loader because it is the loader who creates new processes
+
 - The C runtime because this is the C interpreter
+
 + `bash` because we run `sleepy_creator` from terminal, i.e. from `bash`
 
 ## Feedback

--- a/content/chapters/compute/lab/quiz/why-use-completed-queue.md
+++ b/content/chapters/compute/lab/quiz/why-use-completed-queue.md
@@ -8,7 +8,9 @@ Why does the scheduler need a COMPLETED queue and not simply terminate one threa
 
 - The COMPLETED queue is an implementation preference.
 The scheduler can expose the same functions without it
+
 - Because the OS's scheduler may kill the main kernel-level thread unless we keep the user-level thread in a queue
+
 + The COMPLETED queue is needed to save the value returned by the thread so that it can later be retrieved by `threads_join()`.
 
 ## Feedback

--- a/content/chapters/compute/lecture/demo/create-process/README.md
+++ b/content/chapters/compute/lecture/demo/create-process/README.md
@@ -33,6 +33,7 @@ Hence, the first argumetn we give to `CreateProcess()` is `"cmd /s ls"`.
 
 Run the code and see how `fork()` returns **twice**.
 It creates another process and then returns a different value to each of the two processes:
+
 - it returns 0 to the child process
 - it returns the PID of the child process to the parent
 
@@ -43,7 +44,7 @@ Can you tell how many processes there will be in the end?
 
 Run the code and analyse the process hierarchy using the following output:
 
-```
+```console
 After first fork: PID = 8667; PPID = 6579
  * first fork()
  -- Press ENTER to continue ...

--- a/content/chapters/compute/lecture/quiz/exec-without-fork.md
+++ b/content/chapters/compute/lecture/quiz/exec-without-fork.md
@@ -15,8 +15,11 @@ Why does the shell **NOT** simply call `exec("/bin/ls")`?
 ## Question Answers
 
 - Because `/bin/ls` may be buggy or vulnerable and compromise the shell
+
 + Because when `ls` ends, the shell is closed
+
 - Because the `ls` and `bash` processes must not share the same address space
+
 - Because `bash` needs to pass data to the `ls` process
 
 ## Feedback

--- a/content/chapters/compute/lecture/quiz/not-race-condition.md
+++ b/content/chapters/compute/lecture/quiz/not-race-condition.md
@@ -7,8 +7,11 @@ What type of parallel actions never cause race conditions?
 ## Question Answers
 
 - Only reads
+
 - Reads and writes
+
 + Reads and executions
+
 - All parallel actions can cause race conditions
 
 ## Feedback

--- a/content/chapters/compute/lecture/quiz/number-of-running-threads.md
+++ b/content/chapters/compute/lecture/quiz/number-of-running-threads.md
@@ -7,8 +7,11 @@ What is the maximum number of threads that can be in the RUNNING state at any ti
 ## Question Answers
 
 - All of them
+
 - Only one
+
 - It depends on the ISA
+
 + As many as the number of CPU cores
 
 ## Feedback

--- a/content/chapters/compute/lecture/quiz/process-creation.md
+++ b/content/chapters/compute/lecture/quiz/process-creation.md
@@ -7,6 +7,9 @@ At what stage is a new process created?
 ## Question Answers
 
 + At load time
+
 - At link time
+
 - At runtime
+
 - At compile time

--- a/content/chapters/compute/lecture/quiz/sections-always-shared.md
+++ b/content/chapters/compute/lecture/quiz/sections-always-shared.md
@@ -7,8 +7,11 @@ The pages of which sections in the process virtual address space are **always** 
 ## Question Answers
 
 - None, because they are marked copy-on-write
+
 - Kernel pages because there is only one kernel
+
 + Non-writable sections, such as `.text` or `.rodata`
+
 - `libc` pages, because it is a shared library and all processes refer the same memory
 
 ## Feedback

--- a/content/chapters/compute/lecture/quiz/threads-shared-data.md
+++ b/content/chapters/compute/lecture/quiz/threads-shared-data.md
@@ -7,8 +7,11 @@ Which section may store per-thread non-shared (variables) variables?
 ## Question Answers
 
 - On the heap
+
 - In the `.rodata` section
+
 + On the stack
+
 - In the `.text` section
 
 ## Feedback

--- a/content/chapters/compute/lecture/slides/cool-extra-stuff.md
+++ b/content/chapters/compute/lecture/slides/cool-extra-stuff.md
@@ -32,6 +32,7 @@ student@os:~/.../compute/lecture/demo/create-process$ strace ./fork_exec
 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f7e83aa4810) = 5279
 [...]
 ```
+
 * `fork()` and `pthread_create()` are `libc` wrappers to the same syscall: `clone()`
 
 ---

--- a/content/chapters/compute/lecture/slides/intro.md
+++ b/content/chapters/compute/lecture/slides/intro.md
@@ -9,7 +9,7 @@
 Software running while you are doing your homework:
 
 * Code editor
-* Browser with 10+ https://stackoverflow.com/ tabs
+* Browser with 10+ <https://stackoverflow.com/> tabs
 * Discord
 * Spotify
 * Bittorrent client

--- a/content/chapters/compute/lecture/slides/intro.md
+++ b/content/chapters/compute/lecture/slides/intro.md
@@ -16,7 +16,8 @@ Software running while you are doing your homework:
 * Crypto miner
 * The OS itself
 
-Only one CPU. How?
+Only one CPU.
+How?
 
 ----
 

--- a/content/chapters/compute/lecture/slides/notifications.md
+++ b/content/chapters/compute/lecture/slides/notifications.md
@@ -25,11 +25,14 @@
 #### Two Types of Primitives
 
 1. For mutual exclusion:
-  * mutexes, spinlocks
-  * methods: `lock()` and `unlock()`
+
+* mutexes, spinlocks
+* methods: `lock()` and `unlock()`
+
 1. For ordering:
-  * semaphore, condition variables
-  * methdos: `wait()` and `notify()`
+
+* semaphore, condition variables
+* methdos: `wait()` and `notify()`
 
 ---
 

--- a/content/chapters/compute/lecture/slides/processes.md
+++ b/content/chapters/compute/lecture/slides/processes.md
@@ -4,17 +4,13 @@
 
 ---
 
-<!-- markdownlint-disable MD051 -->
-
 ### Processes
 
 * A process is a **running program**
   * It is a collection of resources (Memory, CPU, I/O) and abstractions over them (VAS, threads, file descriptors)
 * An application can spawn multiple processes
-* The OS allows each [thread](#threads) to run on a **core** for a few milliseconds (time slice)
+* The OS allows each [thread](./threads.md) to run on a **core** for a few milliseconds (time slice)
 * Then the OS pauses the thread and replaces it with another one (context switch)
-
-<!-- markdownlint-enable MD051 -->
 
 ----
 

--- a/content/chapters/compute/lecture/slides/processes.md
+++ b/content/chapters/compute/lecture/slides/processes.md
@@ -4,6 +4,8 @@
 
 ---
 
+<!-- markdownlint-disable MD051 -->
+
 ### Processes
 
 * A process is a **running program**
@@ -11,6 +13,8 @@
 * An application can spawn multiple processes
 * The OS allows each [thread](#threads) to run on a **core** for a few milliseconds (time slice)
 * Then the OS pauses the thread and replaces it with another one (context switch)
+
+<!-- markdownlint-enable MD051 -->
 
 ----
 

--- a/content/chapters/compute/lecture/slides/scheduling-algorithms.md
+++ b/content/chapters/compute/lecture/slides/scheduling-algorithms.md
@@ -53,10 +53,10 @@
 ### Scheduling Algorithms - Round-Robin
 
 1. Add each new thread to a queue
-2. Remove one thread from the queue and run it
-3. The thread runs until finished or until its time slice ends
-4. If the thread is not finished, add it back to the queue
-5. Repeat from step 2
+1. Remove one thread from the queue and run it
+1. The thread runs until finished or until its time slice ends
+1. If the thread is not finished, add it back to the queue
+1. Repeat from step 2
 
 ----
 
@@ -100,7 +100,9 @@ struct schedcoop_private {
 	struct uk_thread_list sleeping_threads;
 };
 ```
+
 * `yield` means scheduling another thread:
+
 ```c
 static void schedcoop_yield(struct uk_sched *s)
 {

--- a/content/chapters/compute/lecture/slides/scheduling.md
+++ b/content/chapters/compute/lecture/slides/scheduling.md
@@ -20,6 +20,8 @@
 
 #### Thread States
 
+<!-- markdownlint-disable MD051 -->
+
 * At most one RUNNING thread per core
 * Queues for BLOCKED and READY threads
 * [Quiz](../quiz/number-of-running-threads.md)
@@ -28,17 +30,19 @@
 
 A more detailed diagram is [here](#the-suspended-states)
 
+<!-- markdownlint-enable MD051 -->
+
 ---
 
 ### Context Switch - When?
 
 * Voluntary - initiated by the running thread:
-    * RUNNING thread performs a blocking action (eg: I/O call)
-    * The thread calls `yield()` / `SwitchToThread()`
+  * RUNNING thread performs a blocking action (eg: I/O call)
+  * The thread calls `yield()` / `SwitchToThread()`
 * Involuntary - initiated by the OS:
-    * RUNNING thread ends
-    * RUNNING thread's time slice expires
-    * A thread with higher priority is READY
+  * RUNNING thread ends
+  * RUNNING thread's time slice expires
+  * A thread with higher priority is READY
 
 ----
 
@@ -78,7 +82,7 @@ nonvoluntary_ctxt_switches:     7
 
 * `demo/context-switch/io_bound.c`:
 
-```
+```console
 student@os:~$ cat /proc/$(pidof io_bound)/status
 [...]
 voluntary_ctxt_switches:        3729

--- a/content/chapters/compute/lecture/slides/scheduling.md
+++ b/content/chapters/compute/lecture/slides/scheduling.md
@@ -20,17 +20,13 @@
 
 #### Thread States
 
-<!-- markdownlint-disable MD051 -->
-
 * At most one RUNNING thread per core
 * Queues for BLOCKED and READY threads
 * [Quiz](../quiz/number-of-running-threads.md)
 
 <img src="media/thread-states.svg" alt="Thread State Diagram" style="width:700px;"/>
 
-A more detailed diagram is [here](#the-suspended-states)
-
-<!-- markdownlint-enable MD051 -->
+A more detailed diagram is [here](./cool-extra-stuff.md#the-suspended-states)
 
 ---
 

--- a/content/chapters/compute/lecture/slides/synchronization.md
+++ b/content/chapters/compute/lecture/slides/synchronization.md
@@ -46,7 +46,6 @@ if (lock = 0) {
 
 ![Race Condition - TOCTOU](./media/race-condition-toctou-generated.gif)
 
-
 * **Wrong:** threads enter critical section simultaneously
 
 ----

--- a/content/chapters/data/lecture/quiz/alloc.md
+++ b/content/chapters/data/lecture/quiz/alloc.md
@@ -5,8 +5,11 @@ When is the major drawback of this allocation strategy?
 ## Question Answers
 
 - Allocating memory upfront is wasteful because you do not use it right away.
+
 + After a few reallocations, you might be allocating too much memory upfront.
+
 - The `appendElem` function becomes more complex.
+
 - The `capacity` field requires extra space which may lead to memory exhaustion when using a large number of `IntArray`s
 
 ## Feedback

--- a/content/chapters/data/lecture/quiz/alloc.md
+++ b/content/chapters/data/lecture/quiz/alloc.md
@@ -14,4 +14,5 @@ When is the major drawback of this allocation strategy?
 
 ## Feedback
 
-The reallocation factor is highly dependant on the use case. For applications that require a long time to use up the memory that they allocated it is better to use a linear function and not an exponential one.
+The reallocation factor is highly dependant on the use case.
+For applications that require a long time to use up the memory that they allocated it is better to use a linear function and not an exponential one.

--- a/content/chapters/data/lecture/quiz/index-out-of-bounds.md
+++ b/content/chapters/data/lecture/quiz/index-out-of-bounds.md
@@ -15,8 +15,11 @@ void main()
 ## Question Answers
 
 - Address is valid so no page fault is issued and the code is executed succesfully
+
 - Address is invalid, therefore "Segmentation Fault" is issued
+
 - Address is valid, but no physical mapping exists so a page fault is issued, a physical page is mapped and execution continues
+
 + all of the above
 
 ## Feedback

--- a/content/chapters/data/lecture/quiz/page_faults.md
+++ b/content/chapters/data/lecture/quiz/page_faults.md
@@ -5,8 +5,11 @@ What entity is responsible for checking the access rights when a memory operatio
 ## Question Answers
 
 - The memory manangement unit
+
 + The page fault handler
+
 - The RAM memory
+
 - The processor
 
 ## Feedback
@@ -14,5 +17,3 @@ What entity is responsible for checking the access rights when a memory operatio
 The MMU simply checks address mappings, not access rights.
 RAM memory is just addressable memory (like the storage unit boxes in our storage unit example).
 The processor simply issues the memory request.
-
-

--- a/content/chapters/data/lecture/quiz/pl.md
+++ b/content/chapters/data/lecture/quiz/pl.md
@@ -8,8 +8,11 @@ Manual Memory Management - MMM
 ## Question Answers
 
 - AMM is easier to use, than MMM
+
 + Programming languages that offer AMM are more complex, therefore development time when using them increases
+
 - MMM may lead to increased program performance when compared to AMM
+
 - MMM exposes the program to memory bugs
 
 ## Feedback

--- a/content/chapters/data/lecture/quiz/swap.md
+++ b/content/chapters/data/lecture/quiz/swap.md
@@ -5,8 +5,11 @@ What happens when there is no more physical memory (RAM) available?
 ## Question Answers
 
 - System freezes
+
 - Memory is freed by deleting some of the least recently used pages
+
 + Memory is freed by moving some pages to the hard disk
+
 - Memory is freed by killing some of the existing processes
 
 ## Feedback

--- a/content/chapters/data/lecture/quiz/vm-draw.md
+++ b/content/chapters/data/lecture/quiz/vm-draw.md
@@ -14,4 +14,5 @@ Which of the following answers does not represent a virtual memory drawback?
 
 ## Feedback
 
-Sharing memory by default between processes is a big security threat. Imagine that each application you installed could access other application's memories.
+Sharing memory by default between processes is a big security threat.
+Imagine that each application you installed could access other application's memories.

--- a/content/chapters/data/lecture/quiz/vm-draw.md
+++ b/content/chapters/data/lecture/quiz/vm-draw.md
@@ -5,12 +5,13 @@ Which of the following answers does not represent a virtual memory drawback?
 ## Question Answers
 
 - It introduces a penalty every time a memory operation is performed.
+
 + Processes do not have access to each others memory by default.
+
 - It requires operating system support.
+
 - It uses extra memory to store the mappings between virtual and physical addresses.
 
 ## Feedback
 
 Sharing memory by default between processes is a big security threat. Imagine that each application you installed could access other application's memories.
-
-

--- a/content/chapters/data/lecture/quiz/vm-final.md
+++ b/content/chapters/data/lecture/quiz/vm-final.md
@@ -5,8 +5,11 @@ What is the chronological order of appearance for the given events for a typical
 ## Question Answers
 
 - memory allocation, memory access, page fault, page fault handling, physical memory allocation, re-execution of the original instruction
+
 + memory allocation, memory access, page fault, page fault handling, re-execution of the original instruction
+
 - memory access, page fault, page fault handling, memory allocation, re-execution of the original instruction
+
 - memory access, page fault, memory allocation, re-execution of the oriringal instruction
 
 ## Feedback
@@ -14,4 +17,3 @@ What is the chronological order of appearance for the given events for a typical
 A typical correct program will first allocate and then access some memory.
 Next, the first access will cause a page fault, then the page fault handler with resolve the situation by allocating a physical frame.
 Therefore, one of the actions that are performed during page fault handling is to allocate physical memory.
-

--- a/content/chapters/io/lecture/demo/file-interface/README.md
+++ b/content/chapters/io/lecture/demo/file-interface/README.md
@@ -10,7 +10,8 @@ To build the C examples on Linux, run `make`.
 
 ### Sparse file
 
-We open a file write some bytes, make a jump using `lseek()` and repeat two times. Zones between writes are empty, yet the total size of the `sparse.dat` keeps track of them.
+We open a file write some bytes, make a jump using `lseek()` and repeat two times.
+Zones between writes are empty, yet the total size of the `sparse.dat` keeps track of them.
 
 Follow this example using the following command to track `sparse.dat` file size.
 
@@ -31,7 +32,8 @@ Expected output:
 
 ### Truncate
 
-We open `fake-gargantua.dat` for write and use `ftruncate()` to set its size to `20GB`. This only impacts the metadata of the file, so the size (number of used blocks) stays **0**.
+We open `fake-gargantua.dat` for write and use `ftruncate()` to set its size to `20GB`.
+This only impacts the metadata of the file, so the size (number of used blocks) stays **0**.
 
 Expected output:
 

--- a/content/chapters/io/lecture/slides/file-interface.md
+++ b/content/chapters/io/lecture/slides/file-interface.md
@@ -140,7 +140,7 @@ What happens if the **offset** is bigger than the file size?
 
 - `demo/file-interface/open-vs-dup.c`
 - `demo/file-interface/close-stdout.c`
-  - What could go wrong between **closing stdout** and **calling dup**?
+  - What could go wrong between **closing** `stdout` and **calling dup**?
   - "Everything."
 
 ----

--- a/content/chapters/software-stack/lab/content/app-investigate.md
+++ b/content/chapters/software-stack/lab/content/app-investigate.md
@@ -32,7 +32,7 @@ As above, the output will differ between systems.
 So, depending on the developers' choice, applications may be:
 
 * compiled into executables, from compiled languages such as C, C++, Go, Rust, D
-* developed as scripts, from interpreted languages such as Python, Perl, Javascript
+* developed as scripts, from interpreted languages such as Python, Perl, JavaScript
 
 #### Practice
 

--- a/content/chapters/software-stack/lab/content/app-investigate.md
+++ b/content/chapters/software-stack/lab/content/app-investigate.md
@@ -5,7 +5,7 @@ For now we know that applications are developed using high-level languages and t
 
 Let's enter the `support/app-investigate/` folder and run the `get_app_types.sh` script:
 
-```
+```console
 student@so:~/.../lab/support/app-investigate$ ./get_app_types.sh
 binary apps: 2223
 Perl apps: 256
@@ -19,7 +19,7 @@ The output will differ between systems, given each has particular types of appli
 
 We list them by running the command inside the `get_app_types.sh` script:
 
-```
+```console
 student@so:~/.../lab/support/app-investigate$ find /usr/bin /bin /usr/sbin /sbin -type f -exec file {} \;
 [...]
 /usr/bin/qpdldecode: ELF 64-bit LSB shared object, x86-64 [...]

--- a/content/chapters/software-stack/lab/content/arena.md
+++ b/content/chapters/software-stack/lab/content/arena.md
@@ -95,8 +95,8 @@ If you get stuck, take a sneak peak at the solutions in the `solution/high-level
    Both files are passed as the two command-line arguments for the program.
    Sample run:
 
-   ```
-   $ cp src dest
+   ```console
+   student@so:~$ cp src dest
    ```
 
    Use `ltrace` and `strace` to compute the number of library calls and system calls.

--- a/content/chapters/software-stack/lab/content/basic-syscall.md
+++ b/content/chapters/software-stack/lab/content/basic-syscall.md
@@ -10,12 +10,13 @@ The program invokes two system calls: `write` and `exit`.
 The program is duplicated in two files using the two x86 assembly language syntaxes: the Intel / NASM syntax (`hello.asm`) and the AT&T / GAS syntax (`hello.s`).
 
 The implementation follows the [x86_64 Linux calling convention](https://x64.syscall.sh/):
+
 * system call ID is passed in the `rax` register
 * system call arguments are passed, in order, in the `rdi`, `rsi`, `rdx`, `r10`, `r8`, `r9` registers
 
 Let's build and run the two programs:
 
-```
+```console
 student@os:~/.../lab/support/basic-syscall$ ls
 hello.asm  hello.s  Makefile
 
@@ -41,7 +42,7 @@ You can also check the online man pages: [`write`](https://man7.org/linux/man-pa
 
 We use `strace` to inspect system calls issued by a program:
 
-```
+```console
 student@os:~/.../lab/support/basic-syscall$ strace ./hello-nasm
 execve("./hello-nasm", ["./hello-nasm"], 0x7ffc4e175f00 /* 63 vars */) = 0
 write(1, "Hello, world!\n", 14Hello, world!
@@ -51,6 +52,7 @@ exit(0)                                 = ?
 ```
 
 There are three system calls captured by `strace`:
+
 * `execve`: this is issued by the shell to create the new process;
   you'll find out more about `execve` in the "Compute" chapter
 * `write`: called by the program to print `Hello, world!` to standard output

--- a/content/chapters/software-stack/lab/content/common-functions.md
+++ b/content/chapters/software-stack/lab/content/common-functions.md
@@ -17,7 +17,7 @@ We print messages using the `write()` system call wrapper implemented in `syscal
 
 Let's build and run the program:
 
-```
+```console
 student@os:~/.../lab/support/common-functions$ make main_string
 gcc -fno-stack-protector   -c -o main_string.o main_string.c
 gcc -fno-stack-protector   -c -o string.o string.c
@@ -47,7 +47,7 @@ The `main()` function `main_printf.c` file contains all the string and printing 
 
 Let's build and run the program:
 
-```
+```console
 student@os:~/.../lab/support/common-functions$ make main_printf
 gcc -fno-stack-protector   -c -o printf.o printf.c
 gcc -nostdlib -no-pie -Wl,--entry=main -Wl,--build-id=none  main_printf.o printf.o string.o syscall.o   -o main_printf

--- a/content/chapters/software-stack/lab/content/high-level-lang.md
+++ b/content/chapters/software-stack/lab/content/high-level-lang.md
@@ -8,14 +8,14 @@ Such that a call to a function in Python would end-up making a call to a functio
 The `support/high-level-lang/` folder stores the implementation of a simple "Hello, World!"-printing program in Python.
 We simply invoke the `python` interpreter to run the program:
 
-```
+```console
 student@os:~/.../lab/support/high-level-lang$ python hello.py
 Hello, world!
 ```
 
 We count the number of functions called from the standard C library and the number of system calls:
 
-```
+```console
 student@os:~/.../lab/support/high-level-lang$ ltrace -l 'libc*' python hello.py 2> libc.out
 Hello, world!
 
@@ -31,7 +31,7 @@ student@os:~/.../lab/support/high-level-lang$ wc -l syscall.out
 
 The dynamic standard C library (`libc.so.6`) is a dependency of the Python interpreter (`/usr/bin/python3`):
 
-```
+```console
 student@os:~/.../lab/support/high-level-lang$ ldd /usr/bin/python3
 [...]
         libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa6fd6d0000)
@@ -45,7 +45,7 @@ Each new layer in the software stack simplifies development but adds overhead.
 
 We can use `perf` to compare the running time between the Python and a C "Hello, World!"-printing programs:
 
-```
+```console
 student@os:~/.../lab/support/high-level-lang$ sudo perf stat ../static-dynamic/hello
 Hello, World!
 
@@ -102,7 +102,7 @@ Enter the `support/high-level-lang/` folder and go through the practice items be
 
    Compare the values with those from the "Hello, World!"-printing programs in C and Python.
 
-2. Create a "Hello, World!"-printing program in a programming language of your choice (other than C, Python and Go).
+1. Create a "Hello, World!"-printing program in a programming language of your choice (other than C, Python and Go).
    Find the values above (library calls, system calls and running time).
 
 [Quiz](../quiz/high-level-lang.md)

--- a/content/chapters/software-stack/lab/content/introduction.md
+++ b/content/chapters/software-stack/lab/content/introduction.md
@@ -5,7 +5,7 @@
 If you have already cloned the repository, make sure it is updated.
 Run this command inside the repository clone directory:
 
-```
+```console
 git pull --rebase
 ```
 
@@ -14,14 +14,14 @@ If that is the case, commit changes and retry.
 
 If you haven't already cloned the repository, do it and enter the repository:
 
-```
+```console
 git clone https://github.com/open-education-hub/operating-systems
 cd operating-sytems
 ```
 
 While inside the repository clone top directory, run the `update-repo.sh` script:
 
-```
+```console
 bash util/update-repo.sh software-stack
 ```
 
@@ -30,7 +30,7 @@ If that is the case, commit changes and re-run the script.
 
 Navigate to the chapter lab directory:
 
-```
+```console
 cd content/chapters/software-stack/lab/
 ```
 

--- a/content/chapters/software-stack/lab/content/libc.md
+++ b/content/chapters/software-stack/lab/content/libc.md
@@ -26,7 +26,7 @@ These programs are almost identical to those used in the past sections:
 
 Let's build and run them:
 
-```
+```console
 student@os:~/.../lab/support/libc$ ls
 hello  hello.c  hello.o  main_printf  main_printf.c  main_printf.o  main_string  main_string.c  main_string.o  Makefile
 
@@ -70,7 +70,7 @@ abc
 
 The behavior / output is similar to the ones in the previous sections:
 
-```
+```console
 student@os:~/.../lab/support/libc$ ../../solution/basic-syscall/hello-nasm
 Hello, world!
 Bye, world!
@@ -93,7 +93,7 @@ abc
 We can inspect the system calls made to check the similarities.
 For example, for the `main_printf` program we get the outputs:
 
-```
+```console
 student@os:~/.../lab/support/libc$ strace ./main_printf
 execve("./main_printf", ["./main_printf"], 0x7fff7b38c240 /* 66 vars */) = 0
 brk(NULL)                               = 0x15af000

--- a/content/chapters/software-stack/lab/content/libcall-syscall.md
+++ b/content/chapters/software-stack/lab/content/libcall-syscall.md
@@ -12,7 +12,7 @@ A library call could be mapped to no system calls, one system call, two or more 
 The `support/libcall-syscall/` folder stores the implementation of a simple program that makes different library calls.
 Let's build the program and then trace the library calls (with `ltrace`) and the system calls (with `strace`):
 
-```
+```console
 student@os:~/.../lab/support/libcall-syscall$ make
 cc -Wall   -c -o call.o call.c
 cc   call.o   -o call
@@ -38,6 +38,7 @@ exit_group(0)                           = ?
 ```
 
 We have the following mappings:
+
 * The `fopen()` library call invokes the `openat` and the `fstat` system calls.
 * The `fwrite()` library call invokes no system calls.
 * The `strlen()` library call invokes no system calls.

--- a/content/chapters/software-stack/lab/content/modern-sw-stack.md
+++ b/content/chapters/software-stack/lab/content/modern-sw-stack.md
@@ -20,6 +20,7 @@ More than these wrappers, the standard C library provides its own API that is ty
 Part of the API exposed by the standard C library is the **standard C API**, also called **ANSI C** or **ISO C**;
 this API is typically portable across all platforms (operating systems and hardware).
 This API, going beyond system call wrappers, has several advantages:
+
 * portability: irrespective of the underlying operating system (and system call API), the API is the same
 * extensive features: string management, I/O formatting
 * possibility of increased efficiency with techniques such as buffering, as we show later

--- a/content/chapters/software-stack/lab/content/overview.md
+++ b/content/chapters/software-stack/lab/content/overview.md
@@ -11,16 +11,19 @@ Moreover, these pieces of instructions can be duplicated and run on different pi
 All we are left with is creating those pieces of instructions, also called programs.
 
 In summary, software has intrinsic characteristics:
+
 * **flexibility**: We can (easily) create new pieces of software.
   Little is required, we don't need raw materials as in the case of hardware or housing or transportation.
 * **reusability**: Software can be easily copied to new systems and provide the same benefits there.
 
 Other characteristics are important to have, as they make life easier for both users and developers of software:
+
 * **portability**: This is the ability to build and run the same program on different computing platforms.
   This allows a developer to write the application code once and then run it everywhere.
 * **fast development**: We want developers to be able to write code faster, using higher-level programming languages.
 
 The last two characteristics rely on two items:
+
 * **higher-level programming languages**: As discussed above, a compiler will take a higher-level program and transform it into binary code for different computing platforms, thus providing portability.
   Also, it's easier to read (comprehend) and write (develop) source code in a higher-level programming language, thus providing fast development.
 * **software stacks**: A software stack is the layering of software such that each lower layer provides a set of features that the higher layer can directly use.

--- a/content/chapters/software-stack/lab/content/static-dynamic.md
+++ b/content/chapters/software-stack/lab/content/static-dynamic.md
@@ -6,7 +6,7 @@ Typically, the executables found in modern operating systems are dynamically-lin
 The `support/static-dynamic/` folder stores the implementation of a simple "Hello, World!"-printing program that uses both static and dynamic linking of libraries.
 Let's build and run the two executables:
 
-```
+```console
 student@os:~/.../lab/support/static-dynamic$ ls
 hello.c  Makefile
 
@@ -34,7 +34,7 @@ The two executables (`hello` and `hello_static`) behave similarly, despite havin
 
 We use `nm` and `ldd` to catch differences between the two types of resulting executables:
 
-```
+```console
 student@os:~/.../lab/support/static-dynamic$ ldd hello
         linux-vdso.so.1 (0x00007ffc8d9b2000)
         libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f10d1d88000)
@@ -56,7 +56,7 @@ Also, given the statically-linked executable integrated entire parts of statical
 We can use `strace` to see that there are differences in the preparatory system calls for each type of executables.
 For the dynamically-linked executable, the dynamically-linked library (`/lib/x86_64-linux-gnu/libc.so.6`) is opened during runtime:
 
-```
+```console
 student@os:~/.../lab/support/static-dynamic$ strace ./hello
 execve("./hello", ["./hello"], 0x7ffc409c6640 /* 66 vars */) = 0
 brk(NULL)                               = 0x55a72eda6000
@@ -108,7 +108,7 @@ exit_group(0)                           = ?
 
 Similarly, we can investigate a system executable (`/bin/ls`) to see that indeed all referenced dynamically-linked libraries are opened (via the `openat` system call) at runtime:
 
-```
+```console
 student@os:~/.../lab/support/static-dynamic$ ldd $(which ls)
 	linux-vdso.so.1 (0x00007ffc3bdf3000)
 	libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007f092bd88000)

--- a/content/chapters/software-stack/lab/content/syscall-wrapper.md
+++ b/content/chapters/software-stack/lab/content/syscall-wrapper.md
@@ -12,7 +12,7 @@ This way, C programs can be written that make function calls that end up making 
 
 Let's build, run and trace system calls for the program:
 
-```
+```console
 student@os:~/.../lab/support/syscall-wrapper$ ls
 main.c  Makefile  syscall.h  syscall.s
 

--- a/content/chapters/software-stack/lab/quiz/common-functions.md
+++ b/content/chapters/software-stack/lab/quiz/common-functions.md
@@ -1,52 +1,64 @@
-# printf() System Call
+# Common functions
 
-## Question Text
+## printf() System Call
+
+### Question Text
 
 What system call does the `printf()` function invoke?
 
-## Question Answers
+### Question Answers
 
 - `read`
+
 + `write`
+
 - `exec`
+
 - `exit`
 
-## Feedback
+### Feedback
 
 `printf()` invokes the `write` system call to print messages to standard output.
 
-# strcpy() System Call
+## strcpy() System Call
 
-## Question Text
+### Question Text
 
 What system call does the `strcpy()` function invoke?
 
-## Question Answers
+### Question Answers
 
 - `cpy`
+
 - `touch`
+
 - `memcpy`
+
 + no system call
 
-## Feedback
+### Feedback
 
 `strcpy()` doesn't invoke system calls, because it doesn't require any feature that is only provided by the operating system
 
-# printf() vs write
+## printf() vs write
 
-## Question Text
+### Question Text
 
 What are features provided by `printf()` when compared to `write`? (choose 2 answers)
 
-## Question Answers
+### Question Answers
 
 + buffering
+
 - outputs to standard output
+
 - may write to file
+
 + does output formatting
+
 - can work with binary data
 
-## Feedback
+### Feedback
 
 `printf()` can do buffering to reduce the number of system calls.
 Also, `printf()`, as it name suggests (the `f` suffix), does output formatting.

--- a/content/chapters/software-stack/lab/quiz/common-functions.md
+++ b/content/chapters/software-stack/lab/quiz/common-functions.md
@@ -1,4 +1,4 @@
-# Common functions
+# Common Functions
 
 ## printf() System Call
 

--- a/content/chapters/software-stack/lab/quiz/high-level-lang.md
+++ b/content/chapters/software-stack/lab/quiz/high-level-lang.md
@@ -7,8 +7,11 @@ A Python program is not a proper argument for ...
 ## Question Answers
 
 - `ltrace`
+
 - `strace`
+
 - `rm`
+
 + `ldd`
 
 ## Feedback

--- a/content/chapters/software-stack/lab/quiz/libc.md
+++ b/content/chapters/software-stack/lab/quiz/libc.md
@@ -1,34 +1,43 @@
-# malloc
+# libc
 
-## Question Text
+## malloc
+
+### Question Text
 
 What system calls are invoked by the `malloc()` library call for Linux libc? (choose 2 answers)
 
-## Question Answers
+### Question Answers
 
 + `brk`
+
 - `free`
+
 - `dup`
+
 + `mmap`
+
 - `copy`
 
-## Feedback
+### Feedback
 
 Depending on the allocation size, `malloc()` invokes `brk` or `mmap`.
 
-# Syscall Tool
+## Syscall Tool
 
-## Question Text
+### Question Text
 
 Which of following is **not** and advantage of using libc for programs?
 
-## Question Answers
+### Question Answers
 
 - increased portability
+
 + reduced executable size
+
 - richer set of features
+
 - easier development
 
-## Feedback
+### Feedback
 
 When using libc, because we add a new software component, the size of the resulting executable increases.

--- a/content/chapters/software-stack/lab/quiz/libc.md
+++ b/content/chapters/software-stack/lab/quiz/libc.md
@@ -1,6 +1,6 @@
 # libc
 
-## malloc
+## `malloc()`
 
 ### Question Text
 

--- a/content/chapters/software-stack/lab/quiz/libcall-syscall.md
+++ b/content/chapters/software-stack/lab/quiz/libcall-syscall.md
@@ -7,8 +7,11 @@ Which of the following library calls will for sure invoke a system call?
 ## Question Answers
 
 + `fopen()`
+
 - `fwrite()`
+
 - `printf()`
+
 - `strcpy()`
 
 ## Feedback

--- a/content/chapters/software-stack/lab/quiz/libs.md
+++ b/content/chapters/software-stack/lab/quiz/libs.md
@@ -1,35 +1,44 @@
-# Static Executables
+# libs
 
-## Question Text
+## Static Executables
+
+### Question Text
 
 Which of the following tools has no influence over statically-linked executables? (choose 2 answers)
 
-## Question Answers
+### Question Answers
 
 + `ltrace`
+
 - `strace`
+
 - `nm`
+
 + `ldd`
+
 - `rm`
 
-## Feedback
+### Feedback
 
 `ltrace` and `ldd` are used to capture connections to dynamic libraries.
 They have no effect on statically-linked executables.
 
-# Dynamic Libraries
+## Dynamic Libraries
 
-## Question Text
+### Question Text
 
 Which of the following is a dynamic library?
 
-## Question Answers
+### Question Answers
 
 - `libc.a`
+
 + `libc.so`
+
 - `libc.exe`
+
 - `libc.c`
 
-## Feedback
+### Feedback
 
 The `.so` (_shared object_) extension is used for dynamic libraries in Linux.

--- a/content/chapters/software-stack/lab/quiz/software.md
+++ b/content/chapters/software-stack/lab/quiz/software.md
@@ -7,8 +7,11 @@ Which of the following is **not** an advantage of software when compared to hard
 ## Question Answers
 
 - reusability
+
 + performance
+
 - portability
+
 - flexibility
 
 ## Feedback

--- a/content/chapters/software-stack/lab/quiz/syscall-wrapper.md
+++ b/content/chapters/software-stack/lab/quiz/syscall-wrapper.md
@@ -7,8 +7,11 @@ What language do we use to invoke system calls?
 ## Question Answers
 
 + assembly
+
 - C
+
 - C++
+
 - Go
 
 ## Feedback

--- a/content/chapters/software-stack/lab/quiz/syscalls.md
+++ b/content/chapters/software-stack/lab/quiz/syscalls.md
@@ -1,50 +1,61 @@
-# Syscall ID
+# Syscalls
 
-## Question Text
+## Syscall ID
+
+### Question Text
 
 What register stores the system call ID on x86_64?
 
-## Question Answers
+### Question Answers
 
 - `RIP`
+
 - `RSP`
+
 + `RAX`
+
 - `RDX`
 
-## Feedback
+### Feedback
 
 `RAX` is the register used for passing the syscall ID and the result code.
 
-# Syscall Tool
+## Syscall Tool
 
-## Question Text
+### Question Text
 
 What tool do we use to capture system calls?
 
-## Question Answers
+### Question Answers
 
 + `strace`
+
 - `make`
+
 - `gcc`
+
 - `./exec`
 
-## Feedback
+### Feedback
 
 `strace` is used to trace system calls invoked by a running program.
 
-# Syscall Numbers
+## Syscall Numbers
 
-## Question Text
+### Question Text
 
 What is the approximate number of system call numbers in Linux?
 
-## Question Answers
+### Question Answers
 
 - 3
+
 - 30
+
 + 300
+
 - 3000
 
-## Feedback
+### Feedback
 
 As show [here](https://x64.syscall.sh/), they're about 300 system calls in Linux.

--- a/content/chapters/software-stack/lecture/slides/operating-system.md
+++ b/content/chapters/software-stack/lecture/slides/operating-system.md
@@ -98,13 +98,13 @@ Security role: _Reference Monitor_
 
 ### Privileged vs Unprivileged Actions
 
-**Unprivileged**
+#### Unprivileged
 
 * memory access (read, write)
 * logical and arithmetic operations
 * function calls
 
-**Privileged**
+#### Privileged
 
 * I/O resource access (files, network, terminal, time)
 * memory allocation
@@ -158,14 +158,14 @@ Also called **supervisor mode**
 
 * ANSI / ISO
   * standard API, portable across OSes
-  * https://www.iso-9899.info/wiki/The_Standard
+  * <https://www.iso-9899.info/wiki/The_Standard>
 * POSIX
   * standard for UNIX-based OSes: Linux, \*BSD, macOS
   * Windows has a POSIX API
-  * https://pubs.opengroup.org/onlinepubs/9699919799/
+  * <https://pubs.opengroup.org/onlinepubs/9699919799>
 * Windows API
   * formerly Win32 API
-  * https://learn.microsoft.com/en-us/windows/win32/apiindex/windows-api-list
+  * <https://learn.microsoft.com/en-us/windows/win32/apiindex/windows-api-list>
 
 ----
 

--- a/content/chapters/software-stack/lecture/slides/types-of-software.md
+++ b/content/chapters/software-stack/lecture/slides/types-of-software.md
@@ -46,6 +46,7 @@
 ### Applications and Libraries
 
 Common features / attributes
+
 * machine / binary code (for compiled programs)
 * data and instructions sections (`rodata`, `data`, `bss`, `text`)
 * stored as files in the filesystem


### PR DESCRIPTION
* **Disable** `MD024`: Allow multiple headings with the same content
* **Configure** `MD033`: Allow inline HTML img tags
* **Disable** `MD035`: Allow the use of `----`
* **Configure** `MD101`: Remove `true`, `false`, and `root` from the list of keywords
* **Configure** `MD104`: ignore URLs, quoted strings, and specific terms that contain punctuation
* Fix markdownlinter errors on master.