### PR TITLE
software-stack/arena: Fix `AArch64` asm program SEGFAULT and add run rule

### DIFF
--- a/content/chapters/software-stack/lab/solution/basic-syscall/arm/Makefile
+++ b/content/chapters/software-stack/lab/solution/basic-syscall/arm/Makefile
@@ -1,6 +1,7 @@
 CC = aarch64-linux-gnu-gcc
 AS = aarch64-linux-gnu-as
 LDFLAGS = -nostdlib -no-pie -Wl,--entry=main -Wl,--build-id=none
+QEMU = qemu-aarch64
 
 .PHONY: all clean
 
@@ -9,6 +10,9 @@ all: hello
 hello: hello.o
 
 hello.o: hello.s
+
+run: hello
+	$(QEMU) ./hello
 
 clean:
 	-rm -f hello.o hello

--- a/content/chapters/software-stack/lab/solution/basic-syscall/arm/hello.s
+++ b/content/chapters/software-stack/lab/solution/basic-syscall/arm/hello.s
@@ -2,6 +2,13 @@
 
     .lcomm buffer, 128
 
+    /* 
+     * We need to add some padding due to a QEMU bug, present
+     * on the 4.2.1 version, that produces a SEGFAULT;
+     * the program works perfectly fine otherwise
+     */
+    .p2align 12
+
 .equ len, 128
 
 .section .rodata


### PR DESCRIPTION
This PR adds a `Makefile` rule that makes possible running `AArch64` binaries on `x86` machines and provides a hack for a `qemu` bug that introduces a SEGFAULT for the `bss` section. These two changes address the `Porting the initial program to ARM on 64 bits` task from arena.

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>