### PR TITLE
`slides.mk`: Add '-vf format=yuv420p' flag to ffmpegAdd '-vf format=yuv420p' flag to ffmpeg

### DIFF
--- a/content/common/makefile/slides.mk
+++ b/content/common/makefile/slides.mk
@@ -21,7 +21,7 @@ $(SITE): $(SLIDES)
 videos:
 	for TARGET in $(TARGETS); do \
 		$(FFMPEG) -framerate 0.5 -f image2 -y \
-			-i "$(MEDIA_DIR)/$$TARGET/$$TARGET-%d.svg" $(MEDIA_DIR)/$$TARGET-generated.gif; \
+			-i "$(MEDIA_DIR)/$$TARGET/$$TARGET-%d.svg" -vf format=yuv420p $(MEDIA_DIR)/$$TARGET-generated.gif; \
 	done
 
 open: $(SITE)


### PR DESCRIPTION
Not using the flag results in shades of yellow, covering the content.

Signed-off-by: Alex Apostolescu <alexx.apostolescu@gmail.com>