### PR TITLE
io/lab: Fix time command

### DIFF
--- a/content/chapters/io/lab/content/async-io.md
+++ b/content/chapters/io/lab/content/async-io.md
@@ -69,7 +69,7 @@ We use two implementations, in Python and in C.
    For each server, in a different console, we can test to see how well it behaves by running:
 
    ```console
-   student@os:/.../support/async/python$ time client_bench.sh
+   student@os:/.../support/async/python$ time ./client_bench.sh
    ```
 
    You will see a time duration difference between `mp_server.py` and the others, `mp_server.py` runs requests faster.


### PR DESCRIPTION
The time command given in the instructions for benchmarking the various implementations of a server tries to run "client_bench.sh" as if it were a command instead of an executable script, this PR fixes that.