### PR TITLE
io/lecture: Pass interface name as CL argument

### DIFF
--- a/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
+++ b/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
@@ -28,7 +28,6 @@ int main(int argc, const char *argv[])
 		return 0;
 	}
 
-
 	// Create socket
 	s = socket(PF_INET, SOCK_DGRAM, 0);
 	DIE(s < 0, "socket");

--- a/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
+++ b/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
@@ -16,31 +16,36 @@
 
 #include "utils/utils.h"
 
-#define IFNAME			"enp0s31f6"
-
-int main(void)
+int main(int argc, const char *argv[])
 {
+	if (argc < 2) {
+		printf("Usage: %s interface_name\n", argv[0]);
+		return 0;
+	}
 	int s;
 	struct ifreq ifr;
 	int rc;
 	size_t i;
+	char *ifname = malloc(strlen(argv[1]));
+	strcpy(ifname, argv[1]);
 
 	// Create socket
 	s = socket(PF_INET, SOCK_DGRAM, 0);
 	DIE(s < 0, "socket");
 
 	// Call ioctl to populate ifr struct
-	snprintf(ifr.ifr_name, strlen(IFNAME)+1, "%s", IFNAME);
+	snprintf(ifr.ifr_name, strlen(ifname)+1, "%s", ifname);
 	rc = ioctl(s, SIOCGIFHWADDR, &ifr);
 	DIE(rc < 0, "ioctl");
 
 	// Print result
-	printf("Hardware address for interface %s is ", IFNAME);
+	printf("Hardware address for interface %s is ", ifname);
 	for (i = 0; i < IFHWADDRLEN-1; i++)
 		printf("%02x:", ((unsigned char *) ifr.ifr_hwaddr.sa_data)[i]);
 	printf("%02x", ((unsigned char *) ifr.ifr_hwaddr.sa_data)[IFHWADDRLEN-1]);
 	printf("\n");
 
+	free(ifname);
 	close(s);
 	return 0;
 }

--- a/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
+++ b/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
@@ -18,34 +18,33 @@
 
 int main(int argc, const char *argv[])
 {
-	if (argc < 2) {
-		printf("Usage: %s interface_name\n", argv[0]);
-		return 0;
-	}
 	int s;
 	struct ifreq ifr;
 	int rc;
 	size_t i;
-	char *ifname = malloc(strlen(argv[1]));
-	strcpy(ifname, argv[1]);
+
+	if (argc < 2) {
+		printf("Usage: %s interface_name\n", argv[0]);
+		return 0;
+	}
+
 
 	// Create socket
 	s = socket(PF_INET, SOCK_DGRAM, 0);
 	DIE(s < 0, "socket");
 
 	// Call ioctl to populate ifr struct
-	snprintf(ifr.ifr_name, strlen(ifname)+1, "%s", ifname);
+	snprintf(ifr.ifr_name, strlen(argv[1])+1, "%s", argv[1]);
 	rc = ioctl(s, SIOCGIFHWADDR, &ifr);
 	DIE(rc < 0, "ioctl");
 
 	// Print result
-	printf("Hardware address for interface %s is ", ifname);
+	printf("Hardware address for interface %s is ", argv[1]);
 	for (i = 0; i < IFHWADDRLEN-1; i++)
 		printf("%02x:", ((unsigned char *) ifr.ifr_hwaddr.sa_data)[i]);
 	printf("%02x", ((unsigned char *) ifr.ifr_hwaddr.sa_data)[IFHWADDRLEN-1]);
 	printf("\n");
 
-	free(ifname);
 	close(s);
 	return 0;
 }


### PR DESCRIPTION
Interface name in ```demo/devices/hwaddr-ioctl.c``` must be now sent as command line argument. (#65)

Signed-off-by: Rares Croicia <rarescroicia@gmail.com>