### PR TITLE
compute/lab: Replace `sleep` with `wait` call

### DIFF
--- a/content/chapters/compute/lab/content/processes.md
+++ b/content/chapters/compute/lab/content/processes.md
@@ -120,7 +120,7 @@ If you found it, you did something wrong.
 It should be missing.
 Now use `pstree -pac` and look for the `sleep` processes you have just created.
 
-[Quiz](../quiz/parent-of-sleep-processes.md)
+   [Quiz](../quiz/parent-of-sleep-processes.md)
 
 1. Change the code in `sleepy_creator.py` so that the `sleep 1000` processes are the children of `sleepy_creator.py`.
 Kill the previously created `sleep` processes using `killall sleep`.

--- a/content/chapters/compute/lab/content/processes.md
+++ b/content/chapters/compute/lab/content/processes.md
@@ -114,17 +114,82 @@ From the outside, it's as if you were running these commands from the terminal.
 Head over to `support/sleepy/sleepy_creator.py`.
 Use `subprocess.Popen()` to spawn 10 `sleep 1000` processes.
 
-1. Now use the same `pstree -pac` command and look for `sleepy_creator.py`.
-It is a `python3` process, as this is the interpreter that runs the script, but we call it the `sleepy_creator.py` process for simplicity.
-If you found it, you did something wrong.
-It should be missing.
-Now use `pstree -pac` and look for the `sleep` processes you have just created.
+1. Solve `TODO 1`: use `subprocess.Popen()` to spawn 10 `sleep 1000` processes.
+
+   Start the script:
+
+   ```console
+   student@os:~/.../lab/support/sleepy$ python3 sleepy_creator.py
+   ```
+
+   Look for the parent process:
+
+   ```console
+   student@os:~$ ps -e -H -o pid,ppid,cmd | (head -1; grep "python3 sleepy_creator.py")
+   ```
+
+   It is a `python3` process, as this is the interpreter that runs the script, but we call it the `sleepy_creator.py` process for simplicity.
+   No output will be provided by the above command, as the parent process (`sleepy_creator.py`) dies before its child processes (the 10 `sleep 1000` subprocesses) finish their execution.
+   The parent process of the newly created child processes is an `init`-like process: either `systemd`/`init` or another system process that adopts orphan processes.
+   Look for the `sleep` child processes using:
+
+   ```console
+   student@os:~$ ps -e -H -o pid,ppid,cmd | (head -1; grep sleep)
+    PID    PPID         CMD
+   4164    1680     sleep 1000
+   4165    1680     sleep 1000
+   4166    1680     sleep 1000
+   4167    1680     sleep 1000
+   4168    1680     sleep 1000
+   4169    1680     sleep 1000
+   4170    1680     sleep 1000
+   4171    1680     sleep 1000
+   4172    1680     sleep 1000
+   4173    1680     sleep 1000
+   ```
+
+   Notice that the child processes do not have `sleepy_creator.py` as a parent.
+   What's more, as you saw above, `sleepy_creator.py` doesn't even exist anymore.
+   The child processes have been adopted by an `init`-like process (in the output above that process has PID `1680` - `PPID` stands for _parent process ID_).
 
    [Quiz](../quiz/parent-of-sleep-processes.md)
 
-1. Change the code in `sleepy_creator.py` so that the `sleep 1000` processes are the children of `sleepy_creator.py`.
-Kill the previously created `sleep` processes using `killall sleep`.
-Verify that `sleepy_creator.py` remains the parent of the `sleep`s it creates using `pstree -pac`.
+1. Solve `TODO 2`: change the code in `sleepy_creator.py` so that the `sleep 1000` processes remain the children of `sleepy_creator.py`.
+   This means that the parent / creator process must **not** exit until its children have finished their execution.
+   In other words, the parent / creator process must **wait** for the termination of its children.
+   Check out [`Popen.wait()`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait) and add the code that makes the parent / creator process wait for its children.
+   Before anything, terminate the `sleep` processes created above:
+
+   ```console
+   student@os:~$ pkill sleep
+   ```
+
+   Start the program, again, as you did before:
+
+   ```console
+   student@os:~/.../lab/support/sleepy$ python3 sleepy_creator.py
+   ```
+
+   On another terminal, verify that `sleepy_creator.py` remains the parent of the `sleep` processes it creates:
+
+   ```console
+   student@os:~$ ps -e -H -o pid,ppid,cmd | (head -1; grep sleep)
+    PID    PPID                CMD
+   16107   9855         python3 sleepy_creator.py
+   16108   16107           sleep 1000
+   16109   16107           sleep 1000
+   16110   16107           sleep 1000
+   16111   16107           sleep 1000
+   16112   16107           sleep 1000
+   16113   16107           sleep 1000
+   16114   16107           sleep 1000
+   16115   16107           sleep 1000
+   16116   16107           sleep 1000
+   16117   16107           sleep 1000
+   ```
+
+   Note that the parent process `sleepy_creator.py` (`PID 16107`) is still alive and its child processes (the 10 `sleep 1000`) have its ID as their `PPID`.
+   You've successfully waited for the child processes to finish their execution.
 
 #### Practice: Lower level - C
 

--- a/content/chapters/compute/lab/solution/sleepy/sleepy_creator.py
+++ b/content/chapters/compute/lab/solution/sleepy/sleepy_creator.py
@@ -17,5 +17,6 @@ def main():
     for p in procs:
         p.wait()
 
+
 if __name__ == "__main__":
     exit(main())

--- a/content/chapters/compute/lab/solution/sleepy/sleepy_creator.py
+++ b/content/chapters/compute/lab/solution/sleepy/sleepy_creator.py
@@ -1,19 +1,21 @@
 import subprocess
 from sys import exit
-from time import sleep
 
 NUM_SLEEPS = 10
 
 
 def main():
-    # TODO 1: create 10 `sleep 1000` processes using `subprocess.Popen`
+    # TODO 1: Create 10 `sleep 1000` processes using `subprocess.Popen`
     # Use the documentation: https://docs.python.org/3/library/subprocess.html#subprocess.Popen
+    procs = []
     for _ in range(NUM_SLEEPS):
-        subprocess.Popen(["sleep", "1000"])
+        # Create new process and add it to the list of processes.
+        p = subprocess.Popen(["sleep", "1000"])
+        procs.append(p)
 
-    # TODO 2: Make this script also wait for 1000 seconds.
-    sleep(1000)
-
+    # TODO 2: Make the current process wait for its child processes.
+    for p in procs:
+        p.wait()
 
 if __name__ == "__main__":
     exit(main())

--- a/content/chapters/compute/lab/support/sleepy/sleepy_creator.py
+++ b/content/chapters/compute/lab/support/sleepy/sleepy_creator.py
@@ -5,11 +5,10 @@ NUM_SLEEPS = 10
 
 
 def main():
-    # TODO 1: create 10 `sleep 1000` processes using `subprocess.Popen`
+    # TODO 1: Create 10 `sleep 1000` processes using `subprocess.Popen`
     # Use the documentation: https://docs.python.org/3/library/subprocess.html#subprocess.Popen
 
-    # TODO 2: Make this script also wait for 1000 seconds. Use `sleep` from the
-    # `time` module.
+    # TODO 2: Make the current process wait for its child processes.
 
     pass
 


### PR DESCRIPTION
Support and solution files for `sleepy/sleepy_creator.py` demonstrate waiting for child processes by inducing the main process in a subsequent sleep.

A better demonstration of the concept of orphan processes and waiting for children is by explicitly making a call for the `wait` function.

This PR replaces the `sleep` call with `wait`, therefore providing a clearer demo of waiting, that would be continued further in the lab, in the `wait-for-me` and `fork` practice items.

Other solutions, for a more compact program would be:

```python
procs = [subprocess.Popen(["sleep", "1000"]) for _ in range(NUM_SLEEPS)]
list(map(lambda p: p.wait(), procs))
# or 
# [p.wait() for p in procs]
```

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>