### PR TITLE
compute/lab: Fix typos and remove redundant links

### DIFF
--- a/content/chapters/compute/lab/content/benchmarks.md
+++ b/content/chapters/compute/lab/content/benchmarks.md
@@ -3,7 +3,7 @@
 The main criterion we use to rank CPUs is their _computation power_, i.e. their ability to crunch numbers and do math.
 Numerous benchmarks exist out there and they are publicly displayed on sites such as [CPUBenchmark](https://www.cpubenchmark.net/).
 
-This benchmark measures the performance of the computer's CPU in a variety of scenarios:
+For example, a benchmark can measure the performance of the computer's CPU in a variety of scenarios:
 
 - its ability to perform integer operations
 - its speed in floating point arithmetic
@@ -11,10 +11,10 @@ This benchmark measures the performance of the computer's CPU in a variety of sc
 - sorting algorithms and others
 
 You can take a look at what exactly is measured using [this link](https://www.cpubenchmark.net/cpu.php?cpu=AMD+Ryzen+Threadripper+PRO+5995WX).
-It displays the scores obrtained by a high-end CPU.
-Apart from the tests above, other benchmarks might focus on other performance metrics such as branch prediction or prefetching.
+It displays the scores obtained by a high-end CPU.
+Apart from the tests above, other benchmarks might focus on different performance metrics such as branch prediction or prefetching.
 
-Other approaches are less artificial, measuring performance on real-world applications such as compile times and performance in the lastest (and most resource-demanding) video games.
+Other approaches are less artificial, measuring performance on real-world applications such as compile times and performance in the latest (and most resource-demanding) video games.
 The latter metric revolves around how many average FPS (frames per second) a given CPU is able to crank out in a specific video game.
 [This article](https://www.gamersnexus.net/guides/3577-cpu-test-methodology-unveil-for-2020-compile-gaming-more) goes into more detail regarding the methodology of running CPU benchmarks on real-world applications.
 
@@ -29,7 +29,7 @@ However, it is the **operating system** that provides the "brains" for this comp
 Specifically, modern CPUs have the capacity to run multiple tasks in parallel.
 But they do not provide a means to decide which task to run at each moment.
 The OS comes as an _orchestrator_ to **schedule** the way these tasks (that we will later call threads) are allowed to run and use the CPU's resources.
-This way OS tells the CPU what code to run on each CPU core so that it reaches a good balance between high throughput (running many instructions) and fair access to CPU cores.
+This way, the OS tells the CPU what code to run on each CPU core so that it reaches a good balance between high throughput (running many instructions) and fair access to CPU cores.
 
 It is cumbersome for a user-level application to interact directly with the CPU.
 The developer would have to write hardware-specific code which is not scalable and is difficult to maintain.

--- a/content/chapters/compute/lab/content/processes-threads-apache2.md
+++ b/content/chapters/compute/lab/content/processes-threads-apache2.md
@@ -138,12 +138,12 @@ We see a much larger number of threads, as expected.
 ### Practice: Investigate `apache2` Using `strace`
 
 Use `strace` to discover the server document root.
-The document root is the path in the filesystem from where httpd serves all the files requested by the clients.
+The document root is the path in the filesystem from where `httpd` serves all the files requested by the clients.
 
 First you will have to stop the running container using `make stop`, then restart it with `make run-privileged`.
 
 Then you will use `strace` inside the container to attach to the worker processes (use the `-p` option for this).
-You will also have to use `-f` flag with `strace`, so that it will follow all the threads inside the processes.
+You will also have to use the `-f` flag with `strace`, so that it will follow all the threads inside the processes.
 
 After you have attached successfully to all worker processes, use the `curl` command to send a request, like the one in the beginning of this section.
 

--- a/content/chapters/compute/lab/content/processes.md
+++ b/content/chapters/compute/lab/content/processes.md
@@ -250,7 +250,7 @@ Notice what each of the two processes prints:
 Unlike `system()`, who also waits for its child, when using `fork()` we must do the waiting ourselves.
 In order to wait for a process to end, we use the [`waitpid()`](https://linux.die.net/man/2/waitpid) syscall.
 It places the exit code of the child process in the `status` parameter.
-This argument is actually a bitfield containing more information that merely the exit code.
+This argument is actually a bitfield containing more information than merely the exit code.
 To retrieve the exit code, we use the `WEXITSTATUS` macro.
 Keep in mind that `WEXITSTATUS` only makes sens if `WIFEXITED` is true, i.e. if the child process finished on its own and wasn't killed by another one or by an illegal action (such as a seg fault or illegal instruction) for example.
 Otherwise, `WEXITSTATUS` will return something meaningless.
@@ -265,5 +265,12 @@ Use a similar logic and a similar set of prints to those in the support code.
 Take a look at the printed PIDs.
 Make sure the PPID of the "grandchild" is the PID of the child, whose PPID is, in turn, the PID of the parent.
 
-**Moral of the story**: Usually the execution flow is `fork()`, followed by `wait()` (called by the parent) `exit()`, called by the child.
+**Moral of the story**: Usually the execution flow is:
+
+1. `fork()`, followed by
+
+1. `wait()` (called by the parent)
+
+1. `exit()`, called by the child.
+
 The order of last 2 steps may be swapped.

--- a/content/chapters/compute/lab/content/scheduling.md
+++ b/content/chapters/compute/lab/content/scheduling.md
@@ -1,8 +1,5 @@
 ## Scheduling
 
-- <https://github.com/kissen/threads>
-- <https://www.schaertl.me/posts/a-bare-bones-user-level-thread-library/>
-
 Up to now we know that the OS decides which **thread** (not process) runs on each CPU core at each time.
 Now we'll learn about the component that performs this task specifically: **the scheduler**.
 

--- a/content/chapters/compute/lab/content/scheduling.md
+++ b/content/chapters/compute/lab/content/scheduling.md
@@ -202,10 +202,10 @@ However, as we've already stated, they rely on the "good will" of threads to yie
 
 #### Preemptive Scheduling
 
-Preemptive scheduling solve the issue stated above by leaving the task of suspending the currently RUNNING thread and replacing it with another one from the READY queue up to the scheduler.
+Preemptive scheduling solves the issue stated above by leaving the task of suspending the currently RUNNING thread and replacing it with another one from the READY queue up to the scheduler.
 This increases its complexity and the duration of context switches, but threads now are not required to worry about yielding themselves and can focus on running their code and performing the task for which they are created.
 
-Preemptive schedulers assign only allow threads to run for a maximum amount of time, called **time slice** (usually a few milliseconds).
+Preemptive schedulers allow threads to run only for a maximum amount of time, called **time slice** (usually a few milliseconds).
 They use timers which fire when a new time slice passes.
 The firing of one such timer causes a context switch whereby the currently RUNNING thread is _preempted_ (i.e. suspended) and replaced with another one.
 

--- a/content/chapters/compute/lab/content/synchronization.md
+++ b/content/chapters/compute/lab/content/synchronization.md
@@ -79,7 +79,7 @@ This latter overhead comes from the **context switch**s that is necessary for a 
 #### Practice: Wrap the Whole `for` Statements in Critical Sections
 
 Move the calls to `lock()` and `unlock()` outside the `for` statements so that the critical sections become the entire statement.
-Measure the time spent now by the code and compare it with the execution times recorded when the critical sections were made up of only `var--` and `var++`.
+Measure the new time spent by the code and compare it with the execution times recorded when the critical sections were made up of only `var--` and `var++`.
 
 [Quiz](../quiz/coarse-vs-granular-critical-section.md)
 
@@ -100,7 +100,7 @@ Concretely, before initiating an atomic transfer on one of its data buses, the C
 This way, one thread obtains **exclusive** access to the data bus while accessing data.
 As a side note, the critical sections in `support/race-condition/race_condition_mutex.d` are also atomic once they are wrapped between calls to `lock()` and `unlock()`.
 
-As with every hardware feature, the x86 ISA exposes an instruction for atomic operations.
+As with every hardware feature, the `x86` ISA exposes an instruction for atomic operations.
 In particular this instruction is a **prefix**, called `lock`.
 It makes the instruction that follows it run atomically.
 The `lock` prefix ensures that the core performing the instruction has exclusive ownership of the cache line from where the data is transfered for the entire operation.
@@ -188,7 +188,7 @@ If `notify()` is called before any thread has called `wait()`, the first thread 
 
 But this is not all, unfortunately.
 Look at the code in `support/apache2-simulator/apache2_simulator_condition.py`.
-See the main thread call notify once it reads the message.
+See the main thread call `notify()` once it reads the message.
 Notice that this call is within a `with event`: so it acquires some mutex / semaphore.
 
 `acquire()` and `release()` are commonly associated with mutexes or semaphores.


### PR DESCRIPTION
This PR fixes some minor typos from all over the lab text, adds backticks where needed and removes 2 ugly links from the start of the `scheduling` section. These links are introduced in the lab further down and become unnecessary right after the title.

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>