### PR TITLE
{lab,lecture}: Add license to sol and support files

### DIFF
--- a/content/CPPLINT.cfg
+++ b/content/CPPLINT.cfg
@@ -7,4 +7,5 @@ filter=-build/header_guard
 filter=-readability/multiline_comment
 filter=-readability/casting
 filter=-runtime/int
+filter=-runtime/printf
 linelength=120

--- a/content/chapters/app-interact/lab/solution/dbus/get_battery_level.py
+++ b/content/chapters/app-interact/lab/solution/dbus/get_battery_level.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import dbus
 
 system_bus = dbus.SystemBus()

--- a/content/chapters/app-interact/lab/solution/password-cracker/password-cracker-multiprocess.c
+++ b/content/chapters/app-interact/lab/solution/password-cracker/password-cracker-multiprocess.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/content/chapters/app-interact/lab/solution/password-cracker/python/password-cracker-multiprocess-2.py
+++ b/content/chapters/app-interact/lab/solution/password-cracker/python/password-cracker-multiprocess-2.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import hashlib
 import itertools
 import os

--- a/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/app.py
+++ b/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/app.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 import os
 

--- a/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/db.py
+++ b/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/db.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import time
 from typing import List, Tuple

--- a/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/disk.py
+++ b/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/disk.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 import os
 import subprocess

--- a/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/errors.py
+++ b/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/errors.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+
 class VMNotFoundException(Exception):
     pass
 

--- a/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/network.py
+++ b/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/network.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import ipaddress
 import logging
 import socket

--- a/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/utils.py
+++ b/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/utils.py
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 DISK_TMP_PASSWORD = "123456"

--- a/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/vm.py
+++ b/content/chapters/app-interact/lab/solution/so-cloud/so-cloud/vm.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import ipaddress
 import logging
 import os

--- a/content/chapters/app-interact/lab/support/dbus/get_battery_level.py
+++ b/content/chapters/app-interact/lab/support/dbus/get_battery_level.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import dbus
 
 # TODO: get the system bus.

--- a/content/chapters/app-interact/lab/support/password-cracker/password-cracker-multiprocess.c
+++ b/content/chapters/app-interact/lab/support/password-cracker/password-cracker-multiprocess.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/content/chapters/app-interact/lab/support/password-cracker/password-cracker-multithread.c
+++ b/content/chapters/app-interact/lab/support/password-cracker/password-cracker-multithread.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/content/chapters/app-interact/lab/support/password-cracker/python/password-cracker-multiprocess-1.py
+++ b/content/chapters/app-interact/lab/support/password-cracker/python/password-cracker-multiprocess-1.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import hashlib
 import itertools
 from multiprocessing import Pipe, Process

--- a/content/chapters/app-interact/lab/support/password-cracker/python/password-cracker-multiprocess-2.py
+++ b/content/chapters/app-interact/lab/support/password-cracker/python/password-cracker-multiprocess-2.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import hashlib
 import itertools
 from multiprocessing import Pool

--- a/content/chapters/app-interact/lab/support/password-cracker/python/password-cracker-multithread.py
+++ b/content/chapters/app-interact/lab/support/password-cracker/python/password-cracker-multithread.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import hashlib
 import itertools
 from threading import Thread

--- a/content/chapters/app-interact/lab/support/time-server/client.c
+++ b/content/chapters/app-interact/lab/support/time-server/client.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/content/chapters/app-interact/lab/support/time-server/python/client.py
+++ b/content/chapters/app-interact/lab/support/time-server/python/client.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket
 import struct
 import sys

--- a/content/chapters/app-interact/lab/support/time-server/python/server.py
+++ b/content/chapters/app-interact/lab/support/time-server/python/server.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket
 import struct
 import sys

--- a/content/chapters/app-interact/lab/support/time-server/server.c
+++ b/content/chapters/app-interact/lab/support/time-server/server.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/types.h>

--- a/content/chapters/compute/lab/solution/create-process/fork.c
+++ b/content/chapters/compute/lab/solution/create-process/fork.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/content/chapters/compute/lab/solution/mini-shell/mini_shell.c
+++ b/content/chapters/compute/lab/solution/mini-shell/mini_shell.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/content/chapters/compute/lab/solution/race-condition/asm/race_condition_lock.S
+++ b/content/chapters/compute/lab/solution/race-condition/asm/race_condition_lock.S
@@ -1,3 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+
 extern printf
 extern pthread_create
 extern pthread_join

--- a/content/chapters/compute/lab/solution/race-condition/c/race_condition_tls.c
+++ b/content/chapters/compute/lab/solution/race-condition/c/race_condition_tls.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stddef.h>
 #include <stdio.h>
 #include <pthread.h>

--- a/content/chapters/compute/lab/solution/race-condition/d/race_condition_atomic.d
+++ b/content/chapters/compute/lab/solution/race-condition/d/race_condition_atomic.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module race_condition_atomic;
 
 import core.atomic;

--- a/content/chapters/compute/lab/solution/race-condition/d/race_condition_mutex_coarse.d
+++ b/content/chapters/compute/lab/solution/race-condition/d/race_condition_mutex_coarse.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module race_condition_mutex_coarse;
 
 import core.sync.mutex;

--- a/content/chapters/compute/lab/solution/shared-memory/shared_memory.c
+++ b/content/chapters/compute/lab/solution/shared-memory/shared_memory.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <sys/mman.h>
 #include <sys/types.h>

--- a/content/chapters/compute/lab/solution/sleepy/sleepy_creator.c
+++ b/content/chapters/compute/lab/solution/sleepy/sleepy_creator.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/content/chapters/compute/lab/solution/sleepy/sleepy_creator.py
+++ b/content/chapters/compute/lab/solution/sleepy/sleepy_creator.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import subprocess
 from sys import exit
 

--- a/content/chapters/compute/lab/solution/sum-array-bugs/seg-fault/sum_array_processes.d
+++ b/content/chapters/compute/lab/solution/sum-array-bugs/seg-fault/sum_array_processes.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module sum_array_processes;
 
 immutable size_t ARR_LEN = 100_000_000;

--- a/content/chapters/compute/lab/solution/sum-array/python/sum_array_processes.py
+++ b/content/chapters/compute/lab/solution/sum-array/python/sum_array_processes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from math import ceil
 from multiprocessing import Manager, Process
 from random import randint

--- a/content/chapters/compute/lab/solution/sum-array/python/sum_array_threads.py
+++ b/content/chapters/compute/lab/solution/sum-array/python/sum_array_threads.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from math import ceil
 from random import randint
 from sys import argv

--- a/content/chapters/compute/lab/solution/wait-for-me/wait_for_me_processes.py
+++ b/content/chapters/compute/lab/solution/wait-for-me/wait_for_me_processes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from multiprocessing import Process
 from sys import argv
 from time import sleep

--- a/content/chapters/compute/lab/solution/wait-for-me/wait_for_me_threads.d
+++ b/content/chapters/compute/lab/solution/wait-for-me/wait_for_me_threads.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module wait_for_me_threads;
 
 const ARR_LEN = 400;

--- a/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_condition.py
+++ b/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_condition.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from random import randint
 from threading import Condition, Thread
 from time import sleep

--- a/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_semaphore.py
+++ b/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_semaphore.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from random import randint
 from threading import Lock, Semaphore, Thread
 from time import sleep

--- a/content/chapters/compute/lab/support/apache2/make_conn.py
+++ b/content/chapters/compute/lab/support/apache2/make_conn.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket
 import sys
 

--- a/content/chapters/compute/lab/support/create-process/fork.c
+++ b/content/chapters/compute/lab/support/create-process/fork.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/content/chapters/compute/lab/support/create-process/popen.py
+++ b/content/chapters/compute/lab/support/create-process/popen.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import subprocess
 from sys import exit
 

--- a/content/chapters/compute/lab/support/fork-faults/fork_faults.c
+++ b/content/chapters/compute/lab/support/fork-faults/fork_faults.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/content/chapters/compute/lab/support/mini-shell/mini_shell.c
+++ b/content/chapters/compute/lab/support/mini-shell/mini_shell.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/content/chapters/compute/lab/support/race-condition/asm/race_condition_lock.S
+++ b/content/chapters/compute/lab/support/race-condition/asm/race_condition_lock.S
@@ -1,3 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+
 extern printf
 extern pthread_create
 extern pthread_join

--- a/content/chapters/compute/lab/support/race-condition/c/race_condition_tls.c
+++ b/content/chapters/compute/lab/support/race-condition/c/race_condition_tls.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stddef.h>
 #include <stdio.h>
 #include <pthread.h>

--- a/content/chapters/compute/lab/support/race-condition/d/race_condition.d
+++ b/content/chapters/compute/lab/support/race-condition/d/race_condition.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module race_condition;
 
 enum NUM_ITER = 10_000_000;

--- a/content/chapters/compute/lab/support/race-condition/d/race_condition_atomic.d
+++ b/content/chapters/compute/lab/support/race-condition/d/race_condition_atomic.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module race_condition_atomic;
 
 import core.atomic;

--- a/content/chapters/compute/lab/support/race-condition/d/race_condition_mutex.d
+++ b/content/chapters/compute/lab/support/race-condition/d/race_condition_mutex.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module race_condition_mutex;
 
 import core.sync.mutex;

--- a/content/chapters/compute/lab/support/race-condition/python/race_condition.py
+++ b/content/chapters/compute/lab/support/race-condition/python/race_condition.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from threading import Thread
 
 NUM_ITER = 10_000_000

--- a/content/chapters/compute/lab/support/shared-memory/shared_memory.c
+++ b/content/chapters/compute/lab/support/shared-memory/shared_memory.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <sys/mman.h>
 #include <sys/types.h>

--- a/content/chapters/compute/lab/support/sleepy/sleepy_creator.c
+++ b/content/chapters/compute/lab/support/sleepy/sleepy_creator.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/content/chapters/compute/lab/support/sleepy/sleepy_creator.py
+++ b/content/chapters/compute/lab/support/sleepy/sleepy_creator.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import subprocess
 from sys import exit
 

--- a/content/chapters/compute/lab/support/sum-array-bugs/memory-corruption/python/memory_corruption_processes.py
+++ b/content/chapters/compute/lab/support/sum-array-bugs/memory-corruption/python/memory_corruption_processes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from math import ceil
 from multiprocessing import Manager, Process
 from random import randint, seed

--- a/content/chapters/compute/lab/support/sum-array-bugs/memory-corruption/python/memory_corruption_threads.py
+++ b/content/chapters/compute/lab/support/sum-array-bugs/memory-corruption/python/memory_corruption_threads.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from math import ceil
 from random import randint, seed
 from sys import argv

--- a/content/chapters/compute/lab/support/sum-array-bugs/seg-fault/sum_array_processes.d
+++ b/content/chapters/compute/lab/support/sum-array-bugs/seg-fault/sum_array_processes.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module sum_array_processes;
 
 immutable size_t ARR_LEN = 100_000_000;

--- a/content/chapters/compute/lab/support/sum-array-bugs/seg-fault/sum_array_threads.d
+++ b/content/chapters/compute/lab/support/sum-array-bugs/seg-fault/sum_array_threads.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module sum_array_threads;
 
 immutable size_t ARR_LEN = 100_000_000;

--- a/content/chapters/compute/lab/support/sum-array/d/generate_random_array.d
+++ b/content/chapters/compute/lab/support/sum-array/d/generate_random_array.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module generate_random_array;
 
 immutable int MAX_ELEM = 1000;

--- a/content/chapters/compute/lab/support/sum-array/d/sum_array_processes.d
+++ b/content/chapters/compute/lab/support/sum-array/d/sum_array_processes.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module sum_array_processes;
 
 immutable size_t ARR_LEN = 100_000_000;

--- a/content/chapters/compute/lab/support/sum-array/d/sum_array_sequential.d
+++ b/content/chapters/compute/lab/support/sum-array/d/sum_array_sequential.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module sum_array_sequential;
 
 immutable size_t ARR_LEN = 100_000_000;

--- a/content/chapters/compute/lab/support/sum-array/d/sum_array_threads.d
+++ b/content/chapters/compute/lab/support/sum-array/d/sum_array_threads.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module sum_array_threads;
 
 const ARR_LEN = 100_000_000;

--- a/content/chapters/compute/lab/support/sum-array/d/sum_array_threads_reduce.d
+++ b/content/chapters/compute/lab/support/sum-array/d/sum_array_threads_reduce.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module sum_array_threads_reduce;
 
 immutable size_t ARR_LEN = 100_000_000;

--- a/content/chapters/compute/lab/support/sum-array/python/sum_array_sequential.py
+++ b/content/chapters/compute/lab/support/sum-array/python/sum_array_sequential.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from random import randint
 from time import time_ns
 

--- a/content/chapters/compute/lab/support/wait-for-me/wait_for_me_processes.py
+++ b/content/chapters/compute/lab/support/wait-for-me/wait_for_me_processes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 from multiprocessing import Process
 from sys import argv
 from time import sleep

--- a/content/chapters/compute/lab/support/wait-for-me/wait_for_me_threads.d
+++ b/content/chapters/compute/lab/support/wait-for-me/wait_for_me_threads.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 module wait_for_me_threads;
 
 const ARR_LEN = 400;

--- a/content/chapters/compute/lecture/demo/barrier/barrier.py
+++ b/content/chapters/compute/lecture/demo/barrier/barrier.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 from argparse import ArgumentParser
 from threading import Barrier, Thread, current_thread
 
@@ -24,9 +26,7 @@ def main():
 
     threads = []
     for i in range(NUM_THREADS):
-        t = Thread(
-            target=thread_func, name=f"thread-{i}", args=(args.use_barrier,)
-        )
+        t = Thread(target=thread_func, name=f"thread-{i}", args=(args.use_barrier,))
         threads.append(t)
         t.start()
 

--- a/content/chapters/compute/lecture/demo/condition/condition.py
+++ b/content/chapters/compute/lecture/demo/condition/condition.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-License-Identifier: BSD-3-Clause
+
+from threading import Condition, Thread
 from time import sleep
-from threading import Thread, Condition
 
 cond = Condition()
 

--- a/content/chapters/compute/lecture/demo/cooperative-scheduling/app-schedule-threads/main.c
+++ b/content/chapters/compute/lecture/demo/cooperative-scheduling/app-schedule-threads/main.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 
 /* Import user configuration: */

--- a/content/chapters/compute/lecture/demo/create-process/create_process.py
+++ b/content/chapters/compute/lecture/demo/create-process/create_process.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 from multiprocessing import Process
 from os import getpid, getppid
 from time import sleep

--- a/content/chapters/compute/lecture/demo/create-thread/create_thread.py
+++ b/content/chapters/compute/lecture/demo/create-thread/create_thread.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 from os import getpid, getppid
 from threading import Thread
 from time import sleep

--- a/content/chapters/compute/lecture/demo/deadlock/deadlock.py
+++ b/content/chapters/compute/lecture/demo/deadlock/deadlock.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 from threading import Lock, Thread
 from time import sleep
 

--- a/content/chapters/data/lab/support/memory-alloc/d_memory_alloc.d
+++ b/content/chapters/data/lab/support/memory-alloc/d_memory_alloc.d
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3-Clause */
+// SPDX-License-Identifier: BSD-3-Clause
 
 import std.stdio;
 import std.format;

--- a/content/chapters/data/lab/support/memory-corruption/d_segfault.d
+++ b/content/chapters/data/lab/support/memory-corruption/d_segfault.d
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3-Clause */
+// SPDX-License-Identifier: BSD-3-Clause
 
 import std.stdio;
 

--- a/content/chapters/data/lab/support/memory-leak/memory_leak.cpp
+++ b/content/chapters/data/lab/support/memory-leak/memory_leak.cpp
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <iostream>
 
 class Student {

--- a/content/chapters/data/lab/support/memory-vuln/d_memory_vuln.d
+++ b/content/chapters/data/lab/support/memory-vuln/d_memory_vuln.d
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3-Clause */
+// SPDX-License-Identifier: BSD-3-Clause
 
 import std.stdio;
 

--- a/content/chapters/data/lab/support/reference-counting/operators.d
+++ b/content/chapters/data/lab/support/reference-counting/operators.d
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3-Clause */
+// SPDX-License-Identifier: BSD-3-Clause
 
 import std.stdio;
 import core.stdc.stdlib;

--- a/content/chapters/data/lab/support/reference-counting/refcount_skel.d
+++ b/content/chapters/data/lab/support/reference-counting/refcount_skel.d
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3-Clause */
+// SPDX-License-Identifier: BSD-3-Clause
 
 import core.stdc.stdlib : malloc, free;
 import std.stdio : writeln, printf;

--- a/content/chapters/data/lecture/demo/alloc_physical/alloc.c
+++ b/content/chapters/data/lecture/demo/alloc_physical/alloc.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/content/chapters/data/lecture/demo/performance/alloc.c
+++ b/content/chapters/data/lecture/demo/performance/alloc.c
@@ -1,13 +1,14 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 
 #define N 10
 
-typedef struct IntArray
-{
+typedef struct IntArray {
     size_t len;
     int* ptr;
-}IntArray;
+} IntArray;
 
 IntArray *allocArray(size_t len)
 {
@@ -19,7 +20,7 @@ IntArray *allocArray(size_t len)
 
 void printArray(IntArray *arr)
 {
-    for(int i = 0; i < arr->len; i++)
+    for (int i = 0; i < arr->len; i++)
         printf("%d\n", arr->ptr[i]);
 }
 
@@ -46,8 +47,7 @@ void main()
     printArray(arr);
     printf("==============================\n");
 
-    for(int i = arr->len; i < N + N; i++)
-    {
+    for (int i = arr->len; i < N + N; i++) {
         appendElem(arr, i);
     }
 

--- a/content/chapters/data/lecture/demo/performance/copy.c
+++ b/content/chapters/data/lecture/demo/performance/copy.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdlib.h>
 
 #define N 500000

--- a/content/chapters/data/lecture/demo/performance/reuse.c
+++ b/content/chapters/data/lecture/demo/performance/reuse.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdlib.h>
 
 void* allocateArray(size_t numElems, size_t elemSize)

--- a/content/chapters/data/lecture/demo/performance/smart_alloc.c
+++ b/content/chapters/data/lecture/demo/performance/smart_alloc.c
@@ -1,14 +1,15 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 
 #define N 10
 
-typedef struct IntArray
-{
+typedef struct IntArray {
     size_t capacity;
     size_t len;
     int* ptr;
-}IntArray;
+} IntArray;
 
 IntArray *allocArray(size_t len)
 {
@@ -21,7 +22,7 @@ IntArray *allocArray(size_t len)
 
 void printArray(IntArray *arr)
 {
-    for(int i = 0; i < arr->len; i++)
+    for (int i = 0; i < arr->len; i++)
         printf("%d\n", arr->ptr[i]);
 }
 
@@ -53,8 +54,7 @@ void main()
     printArray(arr);
     printf("==============================\n");
 
-    for(int i = arr->len; i < N + N; i++)
-    {
+    for (int i = arr->len; i < N + N; i++) {
         appendElem(arr, i);
     }
 

--- a/content/chapters/data/lecture/demo/proc_mem/proc-1.c
+++ b/content/chapters/data/lecture/demo/proc_mem/proc-1.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>

--- a/content/chapters/data/lecture/demo/proc_mem/proc-2.c
+++ b/content/chapters/data/lecture/demo/proc_mem/proc-2.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -7,23 +9,21 @@
 
 int main(int argc, char* argv[])
 {
-    if (argc != 4)
-    {
+    if (argc != 4) {
         printf("proc-2  pid  addr  length\n");
         exit(1);
     }
 
-    int           pid  = strtol (argv[1], NULL, 10);
+    int           pid  = strtol(argv[1], NULL, 10);
     unsigned long addr = strtoul(argv[2], NULL, 16);
-    int           len  = strtol (argv[3], NULL, 10);
+    int           len  = strtol(argv[3], NULL, 10);
 
     char* proc_mem = malloc(50);
-    sprintf(proc_mem, "/proc/%d/mem", pid);
+    snprintf(proc_mem, 50, "/proc/%d/mem", pid);
 
     printf("opening %s, address is %ld\n", proc_mem, addr);
     int fd_proc_mem = open(proc_mem, O_RDWR);
-    if (fd_proc_mem == -1)
-    {
+    if (fd_proc_mem == -1) {
         printf("Could not open %s\n", proc_mem);
         exit(1);
     }
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
     char* buf = malloc(len);
 
     lseek(fd_proc_mem, addr, SEEK_SET);
-    read (fd_proc_mem, buf , len     );
+    read(fd_proc_mem, buf , len);
 
     printf("String at %ld in process %d is:\n", addr, pid);
     printf("  %s\n", buf);
@@ -40,8 +40,7 @@ int main(int argc, char* argv[])
     strncpy(buf, "Hello from proc-2", len);
 
     lseek(fd_proc_mem, addr, SEEK_SET);
-    if (write (fd_proc_mem, buf , len     ) == -1)
-    {
+    if (write(fd_proc_mem, buf , len) == -1) {
         printf("Error while writing\n");
         exit(1);
     }

--- a/content/chapters/data/lecture/demo/proc_pagemap/user_prog.c
+++ b/content/chapters/data/lecture/demo/proc_pagemap/user_prog.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/content/chapters/data/lecture/demo/proc_pagemap/virt_to_phys_user.c
+++ b/content/chapters/data/lecture/demo/proc_pagemap/virt_to_phys_user.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <fcntl.h> /* open */
 #include <stdint.h> /* uint64_t  */
 #include <stdio.h> /* printf */

--- a/content/chapters/data/lecture/demo/proc_storage/decl_var.c
+++ b/content/chapters/data/lecture/demo/proc_storage/decl_var.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 
 int a = 42;

--- a/content/chapters/data/lecture/demo/proc_storage/write_var.c
+++ b/content/chapters/data/lecture/demo/proc_storage/write_var.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/content/chapters/data/lecture/demo/security/bo.c
+++ b/content/chapters/data/lecture/demo/security/bo.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 
@@ -9,20 +11,16 @@ int main(void)
     printf("\n Enter the password : \n");
     scanf("%s", buff);
 
-    if(strcmp(buff, "thegeekstuff"))
-    {
-        printf ("\n Wrong Password \n");
-    }
-    else
-    {
-        printf ("\n Correct Password \n");
+    if (strcmp(buff, "thegeekstuff")) {
+        printf("\n Wrong Password \n");
+    } else {
+        printf("\n Correct Password \n");
         pass = 1;
     }
 
-    if(pass)
-    {
+    if (pass) {
        /* Now Give root or admin rights to user*/
-        printf ("\n Root privileges given to the user \n");
+        printf("\n Root privileges given to the user \n");
     }
 
     return 0;

--- a/content/chapters/data/lecture/demo/security/io.c
+++ b/content/chapters/data/lecture/demo/security/io.c
@@ -1,14 +1,16 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <limits.h>
 
-int foo ( int x)
+int foo(int x)
 {
-    return ( x+1 ) > x ;
+    return (x + 1) > x;
 }
 
-int main ( void )
+int main(void)
 {
-    printf ("% d\n" , ( INT_MAX+1 ) > INT_MAX );
-    printf ("% d\n" , foo ( INT_MAX ));
+    printf("%d\n" , (INT_MAX + 1) > INT_MAX);
+    printf("%d\n" , foo(INT_MAX));
     return 0;
 }

--- a/content/chapters/data/lecture/demo/security/nts.c
+++ b/content/chapters/data/lecture/demo/security/nts.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,10 +10,11 @@ static void see_beyond(const char *s)
     int value = 0xaabbccdd;
     char buffer[32];
 
-    if (strlen(s) < 32)
+    if (strlen(s) < 32) {
         strcpy(buffer, s);
-    else
+    } else {
         memcpy(buffer, s, 32);
+    }
 
     printf("buffer is #%s#\n", buffer);
 }

--- a/content/chapters/data/lecture/demo/space_usage/pragma.c
+++ b/content/chapters/data/lecture/demo/space_usage/pragma.c
@@ -1,8 +1,9 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 
 /*#pragma pack(1)*/
-struct S
-{
+struct S {
     char a;
     int b;
 };
@@ -15,5 +16,4 @@ void main()
 
     printf("%x\n", &s.a);
     printf("%x\n", &s.b);
-
 }

--- a/content/chapters/data/lecture/demo/space_usage/types.c
+++ b/content/chapters/data/lecture/demo/space_usage/types.c
@@ -1,8 +1,9 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 
 // naive version
-typedef struct Creature
-{
+typedef struct Creature {
     int isCat;
     int isDog;
     int isHuman;
@@ -13,12 +14,10 @@ typedef struct Creature
     int sex;
 
     /* potentially other traits */
-
-}Creature;
+} Creature;
 
 // better but not best
-typedef struct BetterCreature
-{
+typedef struct BetterCreature {
     char isCat;
     char isDog;
     char isHuman;
@@ -27,14 +26,13 @@ typedef struct BetterCreature
     char hasLegs;
     char hasTail;
     char hasColdBlood;
-}BetterCreature;
+} BetterCreature;
 
 // best
-typedef struct BestCreature
-{
+typedef struct BestCreature {
     // each bit signifies a traits
     char traits;
-}BestCreature;
+} BestCreature;
 
 #define isCat(p) (p & 1)
 #define isDog(p) (p & 2)
@@ -45,8 +43,7 @@ typedef struct BestCreature
 #define hasTail(p) (p & 64)
 #define hasColdblood(p) (p & 128)
 
-typedef struct BitfieldCreature
-{
+typedef struct BitfieldCreature {
     char isCat : 1;
     char isDog : 1;
     char isHuman : 1;
@@ -55,8 +52,7 @@ typedef struct BitfieldCreature
     char hasLegs : 1;
     char hasTail : 1;
     char hasColdBlood : 1;
-
-}BitfieldCreature;
+} BitfieldCreature;
 
 void main()
 {

--- a/content/chapters/data/lecture/demo/space_usage/union.c
+++ b/content/chapters/data/lecture/demo/space_usage/union.c
@@ -1,30 +1,27 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
-struct String_Internal
-{
+struct String_Internal {
     char* ptr;
     size_t len;
     int capacity;
 };
 
-typedef union String
-{
+typedef union String {
     struct String_Internal long_str;
     char small_str[24];
-}String;
+} String;
 
 void initString(String* str, char* ptr)
 {
     size_t len = strlen(ptr);
-    if (len < 16)
-    {
+    if (len < 16) {
         strncpy(str->small_str, ptr, len);
         str->long_str.capacity = -1;
-    }
-    else
-    {
+    } else {
         str->long_str.ptr = malloc(len*2);
         strncpy(str->long_str.ptr, ptr, len);
         str->long_str.len = len;
@@ -41,8 +38,7 @@ char* getString(String* str)
 {
     if (str->long_str.capacity == -1)
         return str->small_str;
-    else
-        return str->long_str.ptr;
+    return str->long_str.ptr;
 }
 
 void main()

--- a/content/chapters/data/lecture/demo/variables/c_vars.c
+++ b/content/chapters/data/lecture/demo/variables/c_vars.c
@@ -1,11 +1,12 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 
 #define ON_STACK 1
 #define N 10
 
-typedef struct AttackOnTitanCharacter
-{
+typedef struct AttackOnTitanCharacter {
     size_t id;
     char *name;
 } AttackOnTitanCharacter;
@@ -21,7 +22,7 @@ AttackOnTitanCharacter* createElem(size_t id, char *name)
 
 void freeList(AttackOnTitanCharacter **list, size_t length)
 {
-    for (int i=0; i<length; i++)
+    for (int i = 0; i < length; i++)
         free(list[i]);
 
 #ifndef ON_STACK
@@ -31,13 +32,12 @@ void freeList(AttackOnTitanCharacter **list, size_t length)
 
 void printCharacterList(AttackOnTitanCharacter **list, size_t length)
 {
-    for(int i=0; i < length; i++)
+    for (int i = 0; i < length; i++)
         printf("id = %ld, name = %s\n", list[i]->id, list[i]->name);
 }
 
 void main()
 {
-
 #ifdef ON_STACK
     // allocating the list on the stack
     AttackOnTitanCharacter *list[N];

--- a/content/chapters/data/lecture/demo/variables/d_vars.d
+++ b/content/chapters/data/lecture/demo/variables/d_vars.d
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 import std.stdio;
 import std.format;
 

--- a/content/chapters/data/lecture/demo/variables/python_vars.py
+++ b/content/chapters/data/lecture/demo/variables/python_vars.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+
 class AttackOnTitanCharacter:
     # constructor
     def __init__(self, id, name):
@@ -11,6 +14,7 @@ class AttackOnTitanCharacter:
     # destructor
     def __del__(self):
         print("destroying " + self.name)
+
 
 list = []
 list.append(AttackOnTitanCharacter(1, "Eren"))

--- a/content/chapters/io/lab/solution/buffering/diy_buffering.c
+++ b/content/chapters/io/lab/solution/buffering/diy_buffering.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>

--- a/content/chapters/io/lab/solution/client-server/client.py
+++ b/content/chapters/io/lab/solution/client-server/client.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket  # Exposes the Berkely Sockets API
 
 IP = "127.0.0.1"  # Loopback IP address (localhost)

--- a/content/chapters/io/lab/solution/file-mappings/mmap_cp.c
+++ b/content/chapters/io/lab/solution/file-mappings/mmap_cp.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>

--- a/content/chapters/io/lab/solution/receive-challenges/receive_fifo.c
+++ b/content/chapters/io/lab/solution/receive-challenges/receive_fifo.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/content/chapters/io/lab/support/async/python/async_server.py
+++ b/content/chapters/io/lab/support/async/python/async_server.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 # https://docs.python.org/3/library/asyncio-stream.html
 
 import asyncio

--- a/content/chapters/io/lab/support/async/python/async_server_3.6.py
+++ b/content/chapters/io/lab/support/async/python/async_server_3.6.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 # https://docs.python.org/3.6/library/asyncio-stream.html#asyncio.start_server
 
 import asyncio

--- a/content/chapters/io/lab/support/async/python/client.py
+++ b/content/chapters/io/lab/support/async/python/client.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 import random
 import socket

--- a/content/chapters/io/lab/support/async/python/mp_server.py
+++ b/content/chapters/io/lab/support/async/python/mp_server.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 import multiprocessing
 import socket

--- a/content/chapters/io/lab/support/async/python/mt_server.py
+++ b/content/chapters/io/lab/support/async/python/mt_server.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 import socket
 import sys

--- a/content/chapters/io/lab/support/async/python/server.py
+++ b/content/chapters/io/lab/support/async/python/server.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 import socket
 import sys

--- a/content/chapters/io/lab/support/buffering/diy_buffering.c
+++ b/content/chapters/io/lab/support/buffering/diy_buffering.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>

--- a/content/chapters/io/lab/support/buffering/libc_buffering.c
+++ b/content/chapters/io/lab/support/buffering/libc_buffering.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/content/chapters/io/lab/support/buffering/no_buffering.c
+++ b/content/chapters/io/lab/support/buffering/no_buffering.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/content/chapters/io/lab/support/buffering/printf_buffering.c
+++ b/content/chapters/io/lab/support/buffering/printf_buffering.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 
 int main(void)

--- a/content/chapters/io/lab/support/client-server/client.py
+++ b/content/chapters/io/lab/support/client-server/client.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket  # Exposes the Berkely Sockets API
 
 IP = "127.0.0.1"  # Loopback IP address (localhost)

--- a/content/chapters/io/lab/support/client-server/server.py
+++ b/content/chapters/io/lab/support/client-server/server.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket  # Exposes the Berkely Sockets API
 from os import getpid
 

--- a/content/chapters/io/lab/support/file-mappings/mmap_cp.c
+++ b/content/chapters/io/lab/support/file-mappings/mmap_cp.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>

--- a/content/chapters/io/lab/support/mini-shell/mini_shell.c
+++ b/content/chapters/io/lab/support/mini-shell/mini_shell.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/content/chapters/io/lab/support/receive-challenges/receive_fifo.c
+++ b/content/chapters/io/lab/support/receive-challenges/receive_fifo.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/content/chapters/io/lab/support/redirect/redirect_parallel.c
+++ b/content/chapters/io/lab/support/redirect/redirect_parallel.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <fcntl.h>
 #include <pthread.h>
 #include <stddef.h>
@@ -72,7 +74,6 @@ static void do_stderr_redirect()
 
 	rc = close(fd);
 	DIE(rc < 0, "close");
-
 }
 
 void *redirected_print(void *arg)

--- a/content/chapters/io/lab/support/send-receive/receiver.py
+++ b/content/chapters/io/lab/support/send-receive/receiver.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket  # Exposes the Berkely Sockets API
 from os import getpid
 

--- a/content/chapters/io/lab/support/send-receive/sender.py
+++ b/content/chapters/io/lab/support/send-receive/sender.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket  # Exposes the Berkely Sockets API
 
 IP = "127.0.0.1"  # Loopback IP address (localhost)

--- a/content/chapters/io/lab/support/simple-file-operations/FileOperations.java
+++ b/content/chapters/io/lab/support/simple-file-operations/FileOperations.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;

--- a/content/chapters/io/lab/support/simple-file-operations/file_operations.py
+++ b/content/chapters/io/lab/support/simple-file-operations/file_operations.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 FILE_NAME = "file.txt"
 
 

--- a/content/chapters/io/lab/support/zero-copy/benchmark_client.py
+++ b/content/chapters/io/lab/support/zero-copy/benchmark_client.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket
 import sys
 from timeit import default_timer as timer

--- a/content/chapters/io/lab/support/zero-copy/server.py
+++ b/content/chapters/io/lab/support/zero-copy/server.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 import socket
 from threading import Thread
 

--- a/content/chapters/io/lecture/demo/devices/filesystem-size.c
+++ b/content/chapters/io/lecture/demo/devices/filesystem-size.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 /*
  * Use ioctl to get number of bytes in filesystem.
  *

--- a/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
+++ b/content/chapters/io/lecture/demo/devices/hwaddr-ioctl.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 /*
  * Use ioctl to get MAC address of network interface.
  *

--- a/content/chapters/io/lecture/demo/file-interface/c-file-ops.c
+++ b/content/chapters/io/lecture/demo/file-interface/c-file-ops.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/content/chapters/io/lecture/demo/file-interface/close-stdout.c
+++ b/content/chapters/io/lecture/demo/file-interface/close-stdout.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/content/chapters/io/lecture/demo/file-interface/open-vs-dup.c
+++ b/content/chapters/io/lecture/demo/file-interface/open-vs-dup.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/content/chapters/io/lecture/demo/file-interface/py-file-ops.py
+++ b/content/chapters/io/lecture/demo/file-interface/py-file-ops.py
@@ -1,12 +1,13 @@
-# pylint: disable=missing-function-docstring
 #!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
 
 import sys
 
 
 def wait_for_input(msg):
-    print(f' * {msg}')
-    print(' -- Press ENTER to continue ...')
+    print(f" * {msg}")
+    print(" -- Press ENTER to continue ...")
     sys.stdout.flush()
     sys.stdin.readline()
 

--- a/content/chapters/io/lecture/demo/file-interface/sparse-file.c
+++ b/content/chapters/io/lecture/demo/file-interface/sparse-file.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/content/chapters/io/lecture/demo/file-interface/truncate.c
+++ b/content/chapters/io/lecture/demo/file-interface/truncate.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/content/chapters/io/lecture/demo/optimizations/async_server.py
+++ b/content/chapters/io/lecture/demo/optimizations/async_server.py
@@ -1,25 +1,26 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 # https://docs.python.org/3/library/asyncio-stream.html
 
-import sys
 import asyncio
 import logging
+import sys
 
 
 def fibonacci(num):
     if num in (0, 1):
         return 1
-    return fibonacci(num-1) + fibonacci(num-2)
+    return fibonacci(num - 1) + fibonacci(num - 2)
 
 
 async def handle(reader, writer):
-    logging.info("Received connection from %s",
-                 writer.get_extra_info('peername'))
+    logging.info("Received connection from %s", writer.get_extra_info("peername"))
     response = ""
     try:
         data = await reader.read(256)
-        msg = data.decode('utf-8')
+        msg = data.decode("utf-8")
         logging.debug("Message: %s", msg)
         num = int(msg)
         if num < 0 or num > 34:
@@ -28,7 +29,7 @@ async def handle(reader, writer):
     except ValueError:
         response = "error"
 
-    writer.write(response.encode('utf-8'))
+    writer.write(response.encode("utf-8"))
     await writer.drain()
 
     writer.close()
@@ -45,8 +46,7 @@ async def run_server(port, hostname="0.0.0.0"):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG,
-                        format='%(name)s: %(message)s')
+    logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
 
     if len(sys.argv) != 2:
         print("Usage: {} port".format(sys.argv[0]), file=sys.stderr)

--- a/content/chapters/io/lecture/demo/optimizations/client.py
+++ b/content/chapters/io/lecture/demo/optimizations/client.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
-import sys
-import socket
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
 import random
+import socket
+import sys
 
 
 def handle(connection, num):
@@ -11,8 +13,8 @@ def handle(connection, num):
         num = random.randrange(35)
 
     logging.info("Sending %d", num)
-    connection.send(str(num).encode('utf-8'))
-    response = connection.recv(256).decode('utf-8')
+    connection.send(str(num).encode("utf-8"))
+    response = connection.recv(256).decode("utf-8")
     print("function({:d}): {}".format(num, response))
 
     connection.close()
@@ -27,13 +29,14 @@ def run_client(server_name, server_port, num=-1):
 
 
 def main():
-    logging.basicConfig(level=logging.INFO,
-                        format='%(name)s: %(message)s')
+    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
     random.seed()
 
     if len(sys.argv) < 3 or len(sys.argv) > 4:
-        print("Usage: {} server_name server_port [num]".format(
-            sys.argv[0]), file=sys.stderr)
+        print(
+            "Usage: {} server_name server_port [num]".format(sys.argv[0]),
+            file=sys.stderr,
+        )
         print("  0 <= num <= 34", file=sys.stderr)
         sys.exit(1)
 

--- a/content/chapters/io/lecture/demo/optimizations/fwrite-10000.c
+++ b/content/chapters/io/lecture/demo/optimizations/fwrite-10000.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/content/chapters/io/lecture/demo/optimizations/mp_server.py
+++ b/content/chapters/io/lecture/demo/optimizations/mp_server.py
@@ -1,22 +1,24 @@
 #!/usr/bin/env python3
 
-import sys
-import socket
-import multiprocessing
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
+import multiprocessing
+import socket
+import sys
 
 
 def fibonacci(num):
     if num in (0, 1):
         return 1
-    return fibonacci(num-1) + fibonacci(num-2)
+    return fibonacci(num - 1) + fibonacci(num - 2)
 
 
 def handle(connection, address):
     logging.info("Received connection from %s", address)
     response = ""
     try:
-        msg = connection.recv(256).decode('utf-8')
+        msg = connection.recv(256).decode("utf-8")
         logging.debug("Message: %s", msg)
         num = int(msg)
         if num < 0 or num > 34:
@@ -25,7 +27,7 @@ def handle(connection, address):
     except ValueError:
         response = "error"
 
-    connection.send(response.encode('utf-8'))
+    connection.send(response.encode("utf-8"))
 
     connection.close()
 
@@ -47,9 +49,7 @@ def run_server(port, hostname="0.0.0.0"):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG,
-                        format='%(name)s: %(message)s')
-
+    logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
     if len(sys.argv) != 2:
         print("Usage: {} port".format(sys.argv[0]), file=sys.stderr)
         sys.exit(1)

--- a/content/chapters/io/lecture/demo/optimizations/mt_server.py
+++ b/content/chapters/io/lecture/demo/optimizations/mt_server.py
@@ -1,22 +1,24 @@
 #!/usr/bin/env python3
 
-import sys
-import socket
-import threading
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
+import socket
+import sys
+import threading
 
 
 def fibonacci(num):
     if num in (0, 1):
         return 1
-    return fibonacci(num-1) + fibonacci(num-2)
+    return fibonacci(num - 1) + fibonacci(num - 2)
 
 
 def handle(connection, address):
     logging.info("Received connection from %s", address)
     response = ""
     try:
-        msg = connection.recv(256).decode('utf-8')
+        msg = connection.recv(256).decode("utf-8")
         logging.debug("Message: %s", msg)
         num = int(msg)
         if num < 0 or num > 34:
@@ -25,7 +27,7 @@ def handle(connection, address):
     except ValueError:
         response = "error"
 
-    connection.send(response.encode('utf-8'))
+    connection.send(response.encode("utf-8"))
 
     connection.close()
 
@@ -46,8 +48,7 @@ def run_server(port, hostname="0.0.0.0"):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG,
-                        format='%(name)s: %(message)s')
+    logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
 
     if len(sys.argv) != 2:
         print("Usage: {} port".format(sys.argv[0]), file=sys.stderr)

--- a/content/chapters/io/lecture/demo/optimizations/server.py
+++ b/content/chapters/io/lecture/demo/optimizations/server.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 
-import sys
-import socket
+# SPDX-License-Identifier: BSD-3-Clause
+
 import logging
+import socket
+import sys
 
 
 def fibonacci(num):
     if num in (0, 1):
         return 1
-    return fibonacci(num-1) + fibonacci(num-2)
+    return fibonacci(num - 1) + fibonacci(num - 2)
 
 
 def handle(connection, address):
     logging.info("Received connection from %s", address)
     response = ""
     try:
-        msg = connection.recv(256).decode('utf-8')
+        msg = connection.recv(256).decode("utf-8")
         logging.debug("Message: %s", msg)
         num = int(msg)
         if num < 0 or num > 34:
@@ -24,7 +26,7 @@ def handle(connection, address):
     except ValueError:
         response = "error"
 
-    connection.send(response.encode('utf-8'))
+    connection.send(response.encode("utf-8"))
 
     connection.close()
 
@@ -44,8 +46,7 @@ def run_server(port, hostname="0.0.0.0"):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG,
-                        format='%(name)s: %(message)s')
+    logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
 
     if len(sys.argv) != 2:
         print("Usage: {} port".format(sys.argv[0]), file=sys.stderr)

--- a/content/chapters/io/lecture/demo/optimizations/stdout-vs-stderr.c
+++ b/content/chapters/io/lecture/demo/optimizations/stdout-vs-stderr.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <unistd.h>
 

--- a/content/chapters/io/lecture/demo/optimizations/write-1000-unbuf.c
+++ b/content/chapters/io/lecture/demo/optimizations/write-1000-unbuf.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/content/chapters/io/lecture/demo/optimizations/write-10000.c
+++ b/content/chapters/io/lecture/demo/optimizations/write-10000.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/content/chapters/software-stack/lab/solution/basic-syscall/arm/hello.s
+++ b/content/chapters/software-stack/lab/solution/basic-syscall/arm/hello.s
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 .section .bss
 
     .lcomm buffer, 128

--- a/content/chapters/software-stack/lab/solution/basic-syscall/hello.asm
+++ b/content/chapters/software-stack/lab/solution/basic-syscall/hello.asm
@@ -1,3 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+
 section .bss
 
     buffer resb 128

--- a/content/chapters/software-stack/lab/solution/basic-syscall/hello.s
+++ b/content/chapters/software-stack/lab/solution/basic-syscall/hello.s
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 .section .bss
 
     .lcomm buffer, 128

--- a/content/chapters/software-stack/lab/solution/common-functions/main_printf.c
+++ b/content/chapters/software-stack/lab/solution/common-functions/main_printf.c
@@ -1,6 +1,8 @@
-#include "syscall.h"
-#include "string.h"
-#include "printf.h"
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include "./syscall.h"
+#include "./string.h"
+#include "./printf.h"
 
 static const char src[] = "warhammer40k";
 static char dest[128];

--- a/content/chapters/software-stack/lab/solution/libc/memory.c
+++ b/content/chapters/software-stack/lab/solution/libc/memory.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdlib.h>
 
 int main(void)

--- a/content/chapters/software-stack/lab/solution/libc/vendetta.c
+++ b/content/chapters/software-stack/lab/solution/libc/vendetta.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/content/chapters/software-stack/lab/solution/syscall-wrapper/main.c
+++ b/content/chapters/software-stack/lab/solution/syscall-wrapper/main.c
@@ -1,4 +1,6 @@
-#include "syscall.h"
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include "./syscall.h"
 
 static void reverse_string(char *a, unsigned int len)
 {
@@ -11,7 +13,7 @@ static void reverse_string(char *a, unsigned int len)
 		a[j] = aux;
 	}
 }
-	
+
 static unsigned int itoa(int n, char *a)
 {
 	unsigned int num_digits = 0;

--- a/content/chapters/software-stack/lab/solution/syscall-wrapper/syscall.h
+++ b/content/chapters/software-stack/lab/solution/syscall-wrapper/syscall.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #ifndef SYSCALL_H_
 #define SYSCALL_H_	1
 

--- a/content/chapters/software-stack/lab/solution/syscall-wrapper/syscall.s
+++ b/content/chapters/software-stack/lab/solution/syscall-wrapper/syscall.s
@@ -1,3 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+
 section .text
 
 global read

--- a/content/chapters/software-stack/lab/support/basic-syscall/hello.asm
+++ b/content/chapters/software-stack/lab/support/basic-syscall/hello.asm
@@ -1,3 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+
 section .rodata
 
 hello db "Hello, world!", 10, 0

--- a/content/chapters/software-stack/lab/support/basic-syscall/hello.s
+++ b/content/chapters/software-stack/lab/support/basic-syscall/hello.s
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 .section .rodata
 
 hello:

--- a/content/chapters/software-stack/lab/support/common-functions/main_printf.c
+++ b/content/chapters/software-stack/lab/support/common-functions/main_printf.c
@@ -1,6 +1,8 @@
-#include "syscall.h"
-#include "string.h"
-#include "printf.h"
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include "./syscall.h"
+#include "./string.h"
+#include "./printf.h"
 
 static const char src[] = "warhammer40k";
 static char dest[128];

--- a/content/chapters/software-stack/lab/support/common-functions/main_string.c
+++ b/content/chapters/software-stack/lab/support/common-functions/main_string.c
@@ -1,5 +1,7 @@
-#include "syscall.h"
-#include "string.h"
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include "./syscall.h"
+#include "./string.h"
 
 static const char src[] = "warhammer40k\n";
 static char dest[128];

--- a/content/chapters/software-stack/lab/support/common-functions/string.c
+++ b/content/chapters/software-stack/lab/support/common-functions/string.c
@@ -1,11 +1,12 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include "string.h"
 
 unsigned long strlen(const char *s)
 {
 	unsigned long len;
 
-	for (len = 0; *s != '\0'; s++, len++)
-		;
+	for (len = 0; *s != '\0'; s++, len++) { }
 
 	return len;
 }

--- a/content/chapters/software-stack/lab/support/common-functions/syscall.h
+++ b/content/chapters/software-stack/lab/support/common-functions/syscall.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #ifndef SYSCALL_H_
 #define SYSCALL_H_	1
 

--- a/content/chapters/software-stack/lab/support/common-functions/syscall.s
+++ b/content/chapters/software-stack/lab/support/common-functions/syscall.s
@@ -1,3 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+
 section .text
 
 global write

--- a/content/chapters/software-stack/lab/support/high-level-lang/hello.py
+++ b/content/chapters/software-stack/lab/support/high-level-lang/hello.py
@@ -1,3 +1,5 @@
 #!/usr/bin/env python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+
 print("Hello, world!")

--- a/content/chapters/software-stack/lab/support/libc/hello.c
+++ b/content/chapters/software-stack/lab/support/libc/hello.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <unistd.h>
 
 int main(void)

--- a/content/chapters/software-stack/lab/support/libc/main_printf.c
+++ b/content/chapters/software-stack/lab/support/libc/main_printf.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 

--- a/content/chapters/software-stack/lab/support/libc/main_string.c
+++ b/content/chapters/software-stack/lab/support/libc/main_string.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <string.h>
 #include <unistd.h>
 

--- a/content/chapters/software-stack/lab/support/libcall-syscall/call.c
+++ b/content/chapters/software-stack/lab/support/libcall-syscall/call.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <string.h>
 

--- a/content/chapters/software-stack/lab/support/libcall-syscall/call2.c
+++ b/content/chapters/software-stack/lab/support/libcall-syscall/call2.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/content/chapters/software-stack/lab/support/static-dynamic/hello.c
+++ b/content/chapters/software-stack/lab/support/static-dynamic/hello.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #include <stdio.h>
 
 int main(void)

--- a/content/chapters/software-stack/lab/support/syscall-wrapper/main.c
+++ b/content/chapters/software-stack/lab/support/syscall-wrapper/main.c
@@ -1,4 +1,6 @@
-#include "syscall.h"
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include "./syscall.h"
 
 int main(void)
 {

--- a/content/chapters/software-stack/lab/support/syscall-wrapper/syscall.h
+++ b/content/chapters/software-stack/lab/support/syscall-wrapper/syscall.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
 #ifndef SYSCALL_H_
 #define SYSCALL_H_	1
 

--- a/content/chapters/software-stack/lab/support/syscall-wrapper/syscall.s
+++ b/content/chapters/software-stack/lab/support/syscall-wrapper/syscall.s
@@ -1,3 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+
 section .text
 
 global write


### PR DESCRIPTION
As stated in #87, some files are missing a license. This PR adds the `SPDX-License-Identifier: BSD-3-Clause` to all support and solution files from all labs. It covers `py`, `c`, `cpp`, `d`, `java`, `S`, `s`, `asm` and header files.

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>