### PR TITLE
{data,software-stack}/lab: Update `ltrace` usage

### DIFF
--- a/content/chapters/data/lab/content/investigate-memory.md
+++ b/content/chapters/data/lab/content/investigate-memory.md
@@ -227,6 +227,13 @@ A true memory leak occurs when no pointers refer any memory area.
 
 1. Use `ltrace` to list `malloc()` and `free()` calls made by the investigated system executables.
 
+Note that, as explained in the [Software Stack lab](https://open-education-hub.github.io/operating-systems/Lab/Software-Stack/Libcall-Syscall/content/libcall-syscall), on some systems, `ltrace` does not accurately show the output, due to _now binding_.
+Fear not, you can always check the library calls with a more verbose and harder to parse `ltrace` command:
+
+```console
+student@os:~$ ltrace -x "*"
+```
+
 #### Quiz
 
 TODO

--- a/content/chapters/software-stack/lab/content/libcall-syscall.md
+++ b/content/chapters/software-stack/lab/content/libcall-syscall.md
@@ -49,6 +49,35 @@ The main reason for `fwrite()` not making any system calls is the use of a stand
 Calls the `fwrite()` end up writing to that buffer to reduce the number of system calls.
 Actual system calls are made either when the standard C library buffer is full or when an `fflush()` library call is made.
 
+Note that on some systems, `ltrace` **does not work** as expected, due to **now binding**.
+To avoid this behaviour, you can force the **lazy binding** (based on which `ltrace` is constructed to work).
+An example can be found in `support/libcall-syscall/Makefile`, however for system binaries, such as `ls` or `pwd`, the only alternative is to add the `-x "*"` argument to force the command to trace all symbols in the symbol table:
+
+```console
+student@os:~$ ltrace -x "*" ls
+```
+
+You can always choose what library functions `ltrace` is investigating, by replacing the wildcard with their name:
+
+```console
+student@os:~$ ltrace -x "malloc" -x "free" ls
+malloc@libc.so.6(5)                                                    = 0x55c42b2b8910
+free@libc.so.6(0x55c42b2b8910)                                         = <void>
+malloc@libc.so.6(120)                                                  = 0x55c42b2b8480
+malloc@libc.so.6(12)                                                   = 0x55c42b2b8910
+malloc@libc.so.6(776)                                                  = 0x55c42b2b8930
+malloc@libc.so.6(112)                                                  = 0x55c42b2b8c40
+malloc@libc.so.6(1336)                                                 = 0x55c42b2b8cc0
+malloc@libc.so.6(216)                                                  = 0x55c42b2b9200
+malloc@libc.so.6(432)                                                  = 0x55c42b2b92e0
+malloc@libc.so.6(104)                                                  = 0x55c42b2b94a0
+malloc@libc.so.6(88)                                                   = 0x55c42b2b9510
+malloc@libc.so.6(120)                                                  = 0x55c42b2b9570
+[...]
+```
+
+If you would like to know more about **lazy binding**, **now binding** or **PLT** entries, check out [this blog post](https://maskray.me/blog/2021-09-19-all-about-procedure-linkage-table).
+
 #### Practice
 
 Enter the `support/libcall-syscall/` folder and go through the practice items below.

--- a/content/chapters/software-stack/lab/support/high-level-lang/Makefile
+++ b/content/chapters/software-stack/lab/support/high-level-lang/Makefile
@@ -1,3 +1,5 @@
+LDFLAGS = -z lazy
+
 .PHONY: all clean
 
 all: hello

--- a/content/chapters/software-stack/lab/support/libcall-syscall/Makefile
+++ b/content/chapters/software-stack/lab/support/libcall-syscall/Makefile
@@ -1,4 +1,5 @@
 CFLAGS = -Wall
+LDFLAGS = -z lazy
 
 .PHONY: all clean
 

--- a/content/common/makefile/single.mk
+++ b/content/common/makefile/single.mk
@@ -1,3 +1,5 @@
+LDFLAGS = -z lazy
+
 all: $(BINARY)
 
 # Get the relative path to the directory of the current makefile.


### PR DESCRIPTION
On some systems (such as the SO VM), `ltrace` results in empty outputs for binaries that otherwise make library calls. This is due to `now binding` and affects even system binaries, such as `ls` and `pwd`.

This PR forces the `lazy binding`, by modifying the `LDFLAGS` in Makefiles, and warns students about the potentially missing output for system executables.

Lab files that mention the `ltrace` function are:

```console
maria@ssshadows:~/Documents/school-work/git-stuff/operating-systems.git/content/chapters$ grep -nr "ltrace"
software-stack/lab/quiz/high-level-lang.md:9:- `ltrace`
software-stack/lab/quiz/libs.md:11:+ `ltrace`
software-stack/lab/quiz/libs.md:23:`ltrace` and `ldd` are used to capture connections to dynamic libraries.
software-stack/lab/content/app-investigate.md:45:1. Use `ltrace` and `strace` on the two applications.
software-stack/lab/content/libcall-syscall.md:13:Let's build the program and then trace the library calls (with `ltrace`) and the system calls (with `strace`):
software-stack/lab/content/libcall-syscall.md:22:student@os:~/.../lab/support/libcall-syscall$ ltrace ./call
software-stack/lab/content/libcall-syscall.md:57:   Use `ltrace` and `strace`.
software-stack/lab/content/arena.md:89:   Use `ltrace` and `strace` to compute the number of library calls and system calls.
software-stack/lab/content/arena.md:102:   Use `ltrace` and `strace` to compute the number of library calls and system calls.
software-stack/lab/content/arena.md:117:1. Run `ldd`, `nm`, `strace`, `ltrace` on a statically-linked application executable.
software-stack/lab/content/high-level-lang.md:19:student@os:~/.../lab/support/high-level-lang$ ltrace -l 'libc*' python hello.py 2> libc.out
software-stack/lab/content/high-level-lang.md:100:   Use `ltrace` and `strace` to compute the number of library calls and system calls.
data/lab/content/investigate-memory.md:228:1. Use `ltrace` to list `malloc()` and `free()` calls made by the investigated system executables.
data/lab/content/process-memory.md:458:Run the executable under `ltrace` and `strace`:
data/lab/content/process-memory.md:461:student@os:~/.../lab/support/alloc_size$ ltrace ./alloc_size
data/lab/content/process-memory.md:492:Rebuild the program and rerun it under `ltrace` and `strace`:
data/lab/content/process-memory.md:495:student@os:~/.../lab/support/alloc_size$ ltrace ./alloc_size
```

Fixes: #27 

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>