### PR TITLE
util: Add docker environment to run labs

### DIFF
--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# hadolint ignore=DL3008
 RUN apt-get update &&   \
     apt-get install -y sudo man vim git tmux wget curl  \
     linux-tools-5.15.0-60-generic   \

--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update &&   \
+    apt-get install -y sudo man vim git tmux wget curl  \
+    linux-tools-5.15.0-60-generic   \
+    build-essential \
+    golang  \
+    nasm    \
+    strace  \
+    ltrace  \
+    gawk    \
+    gdc \
+    busybox-static  \
+    valgrind    \
+    libjemalloc-dev \
+    default-jre \
+    lsof    \
+    bind9-host  \
+    net-tools   \
+    netcat  \
+    libssl-dev
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY install-dmd.sh /init-scripts/install-dmd.sh
+RUN /init-scripts/install-dmd.sh
+
+# Create user student
+RUN useradd -ms /bin/bash student && echo "student:student" | chpasswd && usermod -aG sudo student
+USER student
+WORKDIR /home/student
+
+# Configure bash
+RUN echo "PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> ~/.bashrc
+RUN echo "PROMPT_DIRTRIM=3" >> ~/.bashrc
+RUN echo "alias python=python3" >> ~/.bashrc
+
+# Add aliases for labs
+RUN echo 'alias go_ss="cd ~/operating-systems/content/chapters/software-stack/lab/"' >> ~/.bashrc
+RUN echo 'alias go_data="cd ~/operating-systems/content/chapters/data/lab/"' >> ~/.bashrc
+RUN echo 'alias go_compute="cd ~/operating-systems/content/chapters/compute/lab/"' >> ~/.bashrc
+RUN echo 'alias go_io="cd ~/operating-systems/content/chapters/io/lab/"' >> ~/.bashrc
+RUN echo 'alias go_appInt="cd ~/operating-systems/content/chapters/app-interact/lab/"' >> ~/.bashrc
+
+ENTRYPOINT [ "bash" ]

--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -32,16 +32,8 @@ RUN useradd -ms /bin/bash student && echo "student:student" | chpasswd && usermo
 USER student
 WORKDIR /home/student
 
-# Configure bash
-RUN echo "PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> ~/.bashrc
-RUN echo "PROMPT_DIRTRIM=3" >> ~/.bashrc
-RUN echo "alias python=python3" >> ~/.bashrc
-
-# Add aliases for labs
-RUN echo 'alias go_ss="cd ~/operating-systems/content/chapters/software-stack/lab/"' >> ~/.bashrc
-RUN echo 'alias go_data="cd ~/operating-systems/content/chapters/data/lab/"' >> ~/.bashrc
-RUN echo 'alias go_compute="cd ~/operating-systems/content/chapters/compute/lab/"' >> ~/.bashrc
-RUN echo 'alias go_io="cd ~/operating-systems/content/chapters/io/lab/"' >> ~/.bashrc
-RUN echo 'alias go_appInt="cd ~/operating-systems/content/chapters/app-interact/lab/"' >> ~/.bashrc
+# Customize .bashrc
+COPY config_terminal.sh /init-scripts/config_terminal.sh
+RUN cat /init-scripts/config_terminal.sh >> ~/.bashrc
 
 ENTRYPOINT [ "bash" ]

--- a/util/os-runner/Makefile
+++ b/util/os-runner/Makefile
@@ -1,0 +1,26 @@
+OS_HOME=$$HOME/school/os
+OS_IMAGE="os-runner-image"
+OS_CONTAINER="os-runner"
+HOSTNAME="os"
+
+.PHONY: docker-image start run clean
+
+docker-image:
+	docker build -t $(OS_IMAGE) .
+
+start:
+	docker run	\
+		--detach	\
+		--name $(OS_CONTAINER)	\
+		--hostname=$(HOSTNAME)	\
+		--mount type=bind,source="$(OS_HOME)/operating-systems",target=/home/student/operating-systems	\
+		--cap-add SYS_ADMIN	\
+		--env "TERM=xterm-256color"	\
+		-it $(OS_IMAGE)
+
+run:
+	docker exec -it $(OS_CONTAINER) bash
+
+clean:
+	docker container stop $(OS_CONTAINER)
+	docker container rm $(OS_CONTAINER)

--- a/util/os-runner/Makefile
+++ b/util/os-runner/Makefile
@@ -1,4 +1,4 @@
-OS_HOME=$$HOME/school/os
+OS_HOME=
 OS_IMAGE="os-runner-image"
 OS_CONTAINER="os-runner"
 HOSTNAME="os"

--- a/util/os-runner/Makefile
+++ b/util/os-runner/Makefile
@@ -18,7 +18,7 @@ start: docker-image
 		--env "TERM=xterm-256color"	\
 		-it $(OS_IMAGE)
 
-run: docker-image
+attach: docker-image
 	docker exec -it $(OS_CONTAINER) bash
 
 clean:

--- a/util/os-runner/Makefile
+++ b/util/os-runner/Makefile
@@ -1,9 +1,9 @@
-OS_HOME=
+OS_HOME=$(realpath ../../)
 OS_IMAGE="os-runner-image"
 OS_CONTAINER="os-runner"
 HOSTNAME="os"
 
-.PHONY: docker-image start run clean
+.PHONY: docker-image start attach clean
 
 docker-image:
 	docker build -t $(OS_IMAGE) .
@@ -13,7 +13,7 @@ start: docker-image
 		--detach	\
 		--name $(OS_CONTAINER)	\
 		--hostname=$(HOSTNAME)	\
-		--mount type=bind,source="$(OS_HOME)/operating-systems",target=/home/student/operating-systems	\
+		--mount type=bind,source="$(OS_HOME)",target=/home/student/operating-systems	\
 		--cap-add SYS_ADMIN	\
 		--env "TERM=xterm-256color"	\
 		-it $(OS_IMAGE)

--- a/util/os-runner/Makefile
+++ b/util/os-runner/Makefile
@@ -8,7 +8,7 @@ HOSTNAME="os"
 docker-image:
 	docker build -t $(OS_IMAGE) .
 
-start:
+start: docker-image
 	docker run	\
 		--detach	\
 		--name $(OS_CONTAINER)	\
@@ -18,7 +18,7 @@ start:
 		--env "TERM=xterm-256color"	\
 		-it $(OS_IMAGE)
 
-run:
+run: docker-image
 	docker exec -it $(OS_CONTAINER) bash
 
 clean:

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -11,6 +11,6 @@ This is an isolated environment to run the examples and tasks from laboratories 
 
 - `make start` - Start `OS-runner` container
 
-- `make run`   - Attache a new session to `OS-runner` container, this is usefull for tasks requiring multiple terminals
+- `make attach`   - Attach a new session to `OS-runner` container, this is useful for tasks requiring multiple terminals
 
 - `make clean` - Stop `OS-runner` container and delete it

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -1,6 +1,6 @@
 # OS-runner
 
-This is an isolated environment to run the examples and tasks from laboratories.
+This is an isolated environment to run the examples and tasks from laboratories and lectures.
 
 ## Prerequisites
 

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -4,7 +4,7 @@ This is an isolated environment to run the examples and tasks from laboratories 
 
 ## Prerequisites
 
-- [Install docker](https://docs.docker.com/get-docker/)
+- [Install docker](https://get.docker.com/)
 - Change the `OS_HOME` variable from `Makefile` to the directory where you cloned the repository
 
 ## Usage

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -5,7 +5,7 @@ This is an isolated environment to run the examples and tasks from laboratories.
 ## Prerequisites
 
 - [Install docker](https://docs.docker.com/get-docker/)
-- Change`OS_HOME` variable from `Makefile` to the directory where you cloned the repo
+- Change the `OS_HOME` variable from `Makefile` to the directory where you cloned the repository
 
 ## Usage
 

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -9,6 +9,8 @@ This is an isolated environment to run the examples and tasks from laboratories.
 
 ## Usage
 
-`make start` - Start `OS-runner` container
-`make run`   - Attache a new session to `OS-runner` container, this is usefull for tasks requiring multiple terminals
-`make clean` - Stop `OS-runner` container and delete it
+- `make start` - Start `OS-runner` container
+
+- `make run`   - Attache a new session to `OS-runner` container, this is usefull for tasks requiring multiple terminals
+
+- `make clean` - Stop `OS-runner` container and delete it

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -1,0 +1,14 @@
+# OS-runner
+
+This is an isolated environment to run the examples and tasks from laboratories.
+
+## Prerequisites
+
+- [Install docker](https://docs.docker.com/get-docker/)
+- Change`OS_HOME` variable from `Makefile` to the directory where you cloned the repo
+
+## Usage
+
+`make start` - Start `OS-runner` container
+`make run`   - Attache a new session to `OS-runner` container, this is usefull for tasks requiring multiple terminals
+`make clean` - Stop `OS-runner` container and delete it

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -5,7 +5,6 @@ This is an isolated environment to run the examples and tasks from laboratories 
 ## Prerequisites
 
 - [Install docker](https://get.docker.com/)
-- Change the `OS_HOME` variable from `Makefile` to the directory where you cloned the repository
 
 ## Usage
 

--- a/util/os-runner/config_terminal.sh
+++ b/util/os-runner/config_terminal.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Configure terminal
+PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+PROMPT_DIRTRIM=3
+alias python=python3
+
+# Add aliases for labs
+ALIAS_DESC= cat << EOF
+Shortcuts:
+go-ss       - changes directory to Software-Stack lab
+go-data     - changes directory to Data lab
+go-compute  - changes directory to Compute lab
+go-io       - changes directory to IO lab
+go-appInt   - changes directory to App Interaction lab
+EOF
+echo "$ALIAS_DESC"
+
+CHAPTERS_PATH="~/operating-systems/content/chapters"
+alias go-ss="cd $CHAPTERS_PATH/software-stack/lab/"
+alias go-data="cd $CHAPTERS_PATH/data/lab/"
+alias go-compute="cd $CHAPTERS_PATH/compute/lab/"
+alias go-io="cd $CHAPTERS_PATH/io/lab/"
+alias go-appInt="cd $CHAPTERS_PATH/app-interact/lab/"

--- a/util/os-runner/config_terminal.sh
+++ b/util/os-runner/config_terminal.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 # Configure terminal
-PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+# shellcheck disable=2154
+PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$'
 PROMPT_DIRTRIM=3
 alias python=python3
 
 # Add aliases for labs
+# shellcheck disable=1007
 ALIAS_DESC= cat << EOF
 Shortcuts:
 go-ss       - changes directory to Software-Stack lab
@@ -16,9 +18,9 @@ go-appInt   - changes directory to App Interaction lab
 EOF
 echo "$ALIAS_DESC"
 
-CHAPTERS_PATH="~/operating-systems/content/chapters"
-alias go-ss="cd $CHAPTERS_PATH/software-stack/lab/"
-alias go-data="cd $CHAPTERS_PATH/data/lab/"
-alias go-compute="cd $CHAPTERS_PATH/compute/lab/"
-alias go-io="cd $CHAPTERS_PATH/io/lab/"
-alias go-appInt="cd $CHAPTERS_PATH/app-interact/lab/"
+CHAPTERS_PATH="$HOME/operating-systems/content/chapters"
+alias go-ss="cd \$CHAPTERS_PATH/software-stack/lab/"
+alias go-data="cd \$CHAPTERS_PATH/data/lab/"
+alias go-compute="cd \$CHAPTERS_PATH/compute/lab/"
+alias go-io="cd \$CHAPTERS_PATH/io/lab/"
+alias go-appInt="cd '\$CHAPTERS_PATH/app-interact/lab/"

--- a/util/os-runner/config_terminal.sh
+++ b/util/os-runner/config_terminal.sh
@@ -2,7 +2,7 @@
 
 # Configure terminal
 # shellcheck disable=2154
-PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$'
+PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 PROMPT_DIRTRIM=3
 alias python=python3
 

--- a/util/os-runner/install-dmd.sh
+++ b/util/os-runner/install-dmd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+wget https://netcologne.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
+apt-get update --allow-insecure-repositories
+apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
+apt-get update && sudo apt-get install -y dmd-compiler dub


### PR DESCRIPTION
Add Makefile for building and starting the `os-runner` container. `make run` can be used to start a new tty.

This solution does not support GUI applications or nested docker containers. The latter are to be run on the host machine as well.

Known issue:
- terminal overwrites line if the command is too long