### PR TITLE
util: Install `dmd` using the official installation script

### DIFF
--- a/util/os-runner/install-dmd.sh
+++ b/util/os-runner/install-dmd.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-wget https://netcologne.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
-apt-get update --allow-insecure-repositories
-apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
-apt-get update && sudo apt-get install -y dmd-compiler dub
+curl -fsS https://dlang.org/install.sh | bash -s dmd
+# shellcheck source=/dev/null
+source "$(find ~/dlang -maxdepth 1 -name 'dmd-*')/activate"


### PR DESCRIPTION
This also activates the compiler silently, without modifying the prompt.