### PR TITLE
software-stack/lab: Fix syntax for intel example

### DIFF
--- a/content/chapters/software-stack/lab/solution/basic-syscall/hello.asm
+++ b/content/chapters/software-stack/lab/solution/basic-syscall/hello.asm
@@ -16,7 +16,7 @@ global main
 
 main:
     push rbp
-    mov rsp, rbp
+    mov rbp, rsp
 
     ; Call write(1, "Hello, world!\n", 14).
     ; rax <- __NR_write (index of write syscall: 1)

--- a/content/chapters/software-stack/lab/support/basic-syscall/hello.asm
+++ b/content/chapters/software-stack/lab/support/basic-syscall/hello.asm
@@ -10,7 +10,7 @@ global main
 
 main:
     push rbp
-    mov rsp, rbp
+    mov rbp, rsp
 
     ; Call write(1, "Hello, world!\n", 14).
     ; rax <- __NR_write (index of write syscall: 1)


### PR DESCRIPTION
In Intel syntax the destination operand is on the left-hand side.