### PR TITLE
util/os-runner: Switch to buildx. Improve Makefile

### DIFF
--- a/util/os-runner/Makefile
+++ b/util/os-runner/Makefile
@@ -1,14 +1,17 @@
 OS_HOME=$(realpath ../../)
-OS_IMAGE="os-runner-image"
+OS_IMAGE="os-runner-image:$(shell git hash-object Dockerfile)"
 OS_CONTAINER="os-runner"
 HOSTNAME="os"
 
 .PHONY: docker-image start attach clean
 
 docker-image:
-	docker build -t $(OS_IMAGE) .
+ifeq ("$(shell docker images -q $(OS_IMAGE))", "")
+	docker buildx build --platform linux/amd64 -t $(OS_IMAGE) .
+endif
 
 start: docker-image
+ifneq ("$(shell docker container inspect -f '{{.State.Running}}' os-runner)", "true")
 	docker run	\
 		--detach	\
 		--name $(OS_CONTAINER)	\
@@ -17,8 +20,9 @@ start: docker-image
 		--cap-add SYS_ADMIN	\
 		--env "TERM=xterm-256color"	\
 		-it $(OS_IMAGE)
+endif
 
-attach: docker-image
+attach: start
 	docker exec -it $(OS_CONTAINER) bash
 
 clean:


### PR DESCRIPTION
Force building an amd64 image using `buildx`. This is needed as `dlang/dmd` is not available for aarch64.
Makefile changes: tag the image, don't rebuild it if the hash hasn't changed, don't start another container if it's already running.
Tested on macOS and Windows (on Windows, if using Git Bash, you need either `alias docker='winpty docker'` or prefix the attach command as `winpty docker exec`).