### PR TITLE
Makefile dependency & Clean all objects and execs

### DIFF
--- a/content/chapters/software-stack/lab/support/common-functions/Makefile
+++ b/content/chapters/software-stack/lab/support/common-functions/Makefile
@@ -15,7 +15,7 @@ main_printf: main_printf.o printf.o string.o syscall.o
 
 main_printf.o: main_printf.c printf.h syscall.h string.h
 
-printf.o: printf.c string.h
+printf.o: printf.c printf.h
 
 string.o: string.c string.h
 
@@ -23,6 +23,6 @@ syscall.o: syscall.s
 	$(NASM) -f elf64 -o $@ $<
 
 clean:
-	-rm -f main_string
-	-rm -f main_string.o printf.o string.o syscall.o
+	-rm -f main_string main_printf
+	-rm -f *.o
 	-rm -f *~


### PR DESCRIPTION
Replaced the `string.h` dependency with `printf.h`. Added all `.o` files and executables to the `clean` rule.