### PR TITLE
Add python alternative for ltrace/strace 

### DIFF
--- a/content/chapters/software-stack/lab/content/high-level-lang.md
+++ b/content/chapters/software-stack/lab/content/high-level-lang.md
@@ -16,13 +16,13 @@ Hello, world!
 We count the number of functions called from the standard C library and the number of system calls:
 
 ```console
-student@os:~/.../lab/support/high-level-lang$ ltrace -l 'libc*' python hello.py 2> libc.out
+student@os:~/.../lab/support/high-level-lang$ ltrace -l 'libc*' python hello.py 2> libc.out # use python3 if python2 is not installed
 Hello, world!
 
 student@os:~/.../lab/support/high-level-lang$ wc -l libc.out
 50469 out
 
-student@os:~/.../lab/support/high-level-lang$ strace python hello.py 2> syscall.out
+student@os:~/.../lab/support/high-level-lang$ strace python hello.py 2> syscall.out # use python3 if python2 is not installed
 Hello, world!
 
 student@os:~/.../lab/support/high-level-lang$ wc -l syscall.out

--- a/content/chapters/software-stack/lab/content/high-level-lang.md
+++ b/content/chapters/software-stack/lab/content/high-level-lang.md
@@ -16,13 +16,13 @@ Hello, world!
 We count the number of functions called from the standard C library and the number of system calls:
 
 ```console
-student@os:~/.../lab/support/high-level-lang$ ltrace -l 'libc*' python hello.py 2> libc.out # use python3 if python2 is not installed
+student@os:~/.../lab/support/high-level-lang$ ltrace -l 'libc*' python hello.py 2> libc.out
 Hello, world!
 
 student@os:~/.../lab/support/high-level-lang$ wc -l libc.out
 50469 out
 
-student@os:~/.../lab/support/high-level-lang$ strace python hello.py 2> syscall.out # use python3 if python2 is not installed
+student@os:~/.../lab/support/high-level-lang$ strace python hello.py 2> syscall.out
 Hello, world!
 
 student@os:~/.../lab/support/high-level-lang$ wc -l syscall.out

--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -29,7 +29,6 @@ COPY install-dmd.sh /init-scripts/install-dmd.sh
 RUN /init-scripts/install-dmd.sh
 
 # Use python3
-USER root
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 # Create user student

--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -28,6 +28,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 COPY install-dmd.sh /init-scripts/install-dmd.sh
 RUN /init-scripts/install-dmd.sh
 
+# Use python3
+USER root
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
 # Create user student
 RUN useradd -ms /bin/bash student && echo "student:student" | chpasswd && usermod -aG sudo student
 USER student

--- a/util/os-runner/config_terminal.sh
+++ b/util/os-runner/config_terminal.sh
@@ -4,7 +4,6 @@
 # shellcheck disable=2154
 PS1='🐳 ${debian_chroot:+($debian_chroot)}\[\033[01;36m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 PROMPT_DIRTRIM=3
-alias python=python3
 
 # Add aliases for labs
 # shellcheck disable=1007


### PR DESCRIPTION
Use `python3` when `ltrace`-ing or `strace`-ing if you have no python2 version installed. Otherwise, it will throw an error saying "strace: Can't stat 'python': No such file or directory".