### PR TITLE
compute/lab: Fix links in content files

### DIFF
--- a/content/chapters/compute/lab/content/arena.md
+++ b/content/chapters/compute/lab/content/arena.md
@@ -56,7 +56,7 @@ For this reason and because library functions are usually much better tested tha
 
 ## Shared Memory
 
-As you remember from the [Data chapter](../../data/), one way to allocate a given number of pages is to use the `mmap()` syscall.
+As you remember from the [Data chapter](../../../data/), one way to allocate a given number of pages is to use the `mmap()` syscall.
 Let's look at its [man page](https://man7.org/linux/man-pages/man2/mmap.2.html), specifically at the `flags` argument.
 Its main purpose is to determine the way in which child processes interact with the mapped pages.
 

--- a/content/chapters/compute/lab/content/processes.md
+++ b/content/chapters/compute/lab/content/processes.md
@@ -228,7 +228,7 @@ Use `join()` to make the parent wait for its child before reading the file.
 
 Up to now we've been creating processes using various high-level APIs, such as `Popen()`, `Process()` and `system()`.
 Yes, despite being a C function, as you've seen from its man page, `system()` itself calls 2 other functions: `fork()` to create a process and `execve()` to execute the given command.
-As you already know from the [Software Stack](../../software-stack/) chapter, library functions may call one or more underlying system calls or other functions.
+As you already know from the [Software Stack](../../../software-stack/) chapter, library functions may call one or more underlying system calls or other functions.
 Now we will move one step lower on the call stack and call `fork()` ourselves.
 
 `fork()` creates one child process that is _almost_ identical to its parent.

--- a/content/chapters/compute/lab/content/scheduling.md
+++ b/content/chapters/compute/lab/content/scheduling.md
@@ -168,7 +168,7 @@ main thread
 ```
 
 Compile and run the code in `support/libult/test_ult.c`.
-If you encounter the following error when running `test_ult`, remember what you learned about the loader and using custom shared libraries in the [Software Stack lab](../../software-stack/lab).
+If you encounter the following error when running `test_ult`, remember what you learned about the loader and using custom shared libraries in the [Software Stack lab](../../../software-stack/lab).
 
 ```console
 ./test_ult: error while loading shared libraries: libult.so: cannot open shared object file: No such file or directory


### PR DESCRIPTION
There are broken GitHub links to other sections that currently give a `404` result. This PR fixes those links.