### PR TITLE
Use `student@os` consistently as part of the prompt in code snippets

### DIFF
--- a/content/chapters/data/lab/content/investigate-memory.md
+++ b/content/chapters/data/lab/content/investigate-memory.md
@@ -267,7 +267,7 @@ Ioana David is 23 years old and likes macOS
 For example, by using `stats_print:true` we print out information regarding the use of the library functions:
 
 ```console
-razvan@yggdrasil:~/.../lab/support/memory-leak$ LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1 MALLOC_CONF="stats_print:true" ./memory_leak_malloc
+student@os:~/.../lab/support/memory-leak$ LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1 MALLOC_CONF="stats_print:true" ./memory_leak_malloc
 Andrei Popescu is 22 years old and likes Linux
 Ioana David is 23 years old and likes macOS
 ___ Begin jemalloc statistics ___

--- a/content/chapters/data/lab/content/working-memory.md
+++ b/content/chapters/data/lab/content/working-memory.md
@@ -66,11 +66,11 @@ The file uses different access types for the `data` variable and the `do_nothing
 Build it:
 
 ```console
-student@so:~/.../lab/support/memory-protection$ make
+student@os:~/.../lab/support/memory-protection$ make
 gcc -g -Wall -Wextra -Werror -I../../../../../common/makefile/../utils -I../../../../../common/makefile/../utils/log  -c -o mem_prot.o mem_prot.c
 gcc mem_prot.o ../../../../../common/makefile/../utils/log/log.o  -o mem_prot
 
-razvan@yggdrasil:~/.../lab/support/memory-protection$ ./mem_prot
+student@os:~/.../lab/support/memory-protection$ ./mem_prot
 reading from .data section
 writing to .data section
 reading from .text section
@@ -82,7 +82,7 @@ All current actions in the program are valid.
 Let's uncomment each commented line in the program and try again:
 
 ```console
-student@so:~/.../lab/support/memory-protection$ ./mem_prot
+student@os:~/.../lab/support/memory-protection$ ./mem_prot
 reading from .data section
 writing to .data section
 reading from .text section
@@ -99,7 +99,7 @@ But even for programming languages that don't offer pointers (such as Python) is
 In the `str.py` file, we look to modify `str[1]`, but this fails:
 
 ```console
-student@so:~/.../lab/support/memory-protection$ ./str.py 
+student@os:~/.../lab/support/memory-protection$ ./str.py 
 n, 110, n
 Traceback (most recent call last):
   File "./str.py", line 5, in <module>

--- a/content/chapters/io/lecture/demo/devices/README.md
+++ b/content/chapters/io/lecture/demo/devices/README.md
@@ -21,8 +21,8 @@ We create a socket and call `ioctl()` using `SIOCGIFHWADDR` as argument to popul
 Expected output:
 
 ```console
-student@OS:~/.../demo/devices$ # interface name might be different according to personal systems
-student@OS:~/.../demo/devices$ ./hwaddr-ioctl eth0
+student@os:~/.../demo/devices$ # interface name might be different according to personal systems
+student@os:~/.../demo/devices$ ./hwaddr-ioctl eth0
 Hardware address for interface eth0 is 00:00:5e:00:53:af
 ```
 
@@ -38,8 +38,8 @@ We open the filesystem block file from `/dev` and call `ioctl()` using `BLKGETSI
 Expected output:
 
 ```console
-student@OS:~/.../demo/devices$ # partition name might be different according to personal systems
-student@OS:~/.../demo/devices$ ./filesystem-size /dev/sda2
+student@os:~/.../demo/devices$ # partition name might be different according to personal systems
+student@os:~/.../demo/devices$ ./filesystem-size /dev/sda2
 Total space 300.132 GB
 ```
 
@@ -51,7 +51,7 @@ We will be using `read-from-device.sh` bash script to read `100 bytes` from a gi
 Block devices guarantee persistance of data and therefore return the same bytes.
 
 ```console
-student@OS:~/.../demo/devices$ sudo ./read-from-device.sh /dev/sda
+student@os:~/.../demo/devices$ sudo ./read-from-device.sh /dev/sda
 Read 100 bytes from /dev/sda:
 0000000 63eb d090 00bc 8e7c 8ec0 bed8 7c00 00bf
 0000010 b906 0200 f3fc 50a4 1c68 cb06 b9fb 0004
@@ -62,7 +62,7 @@ Read 100 bytes from /dev/sda:
 0000060 0000 0000                              
 0000064
 
-student@OS:~/.../demo/devices$ sudo ./read-from-device.sh /dev/sda
+student@os:~/.../demo/devices$ sudo ./read-from-device.sh /dev/sda
 Read 100 bytes from /dev/sda:
 0000000 63eb d090 00bc 8e7c 8ec0 bed8 7c00 00bf
 0000010 b906 0200 f3fc 50a4 1c68 cb06 b9fb 0004
@@ -78,7 +78,7 @@ Char devices provide information in real-time so we expect a different output if
 Data from char devices are also used by the OS to collect randomness.
 
 ```console
-student@OS:~/.../demo/devices$ ./read-from-device.sh /dev/urandom 
+student@os:~/.../demo/devices$ ./read-from-device.sh /dev/urandom 
 Read 100 bytes from /dev/urandom:
 0000000 9672 15fc 6631 e9f7 6c6f 99c7 5504 e748
 0000010 6a18 6fa0 ffc1 fded b468 b5e9 8121 1187
@@ -89,7 +89,7 @@ Read 100 bytes from /dev/urandom:
 0000060 65f3 3ad8                              
 0000064
 
-student@OS:~/.../demo/devices$ ./read-from-device.sh /dev/urandom 
+student@os:~/.../demo/devices$ ./read-from-device.sh /dev/urandom 
 Read 100 bytes from /dev/urandom:
 0000000 773c e9ff ba84 b7e8 9f76 bba9 6394 4023
 0000010 ddc3 4bd5 8777 5a8e 53a5 6532 1fbd 772a

--- a/content/chapters/io/lecture/demo/optimizations/README.md
+++ b/content/chapters/io/lecture/demo/optimizations/README.md
@@ -16,7 +16,7 @@ The code prints two interleaved sentences: `"Hello from the other side!"` and `"
 Running the code yields a different result than we would expect.
 
 ```console
-student@OS:~/.../demo/optimizations$ ./stdout-vs-stderr
+student@os:~/.../demo/optimizations$ ./stdout-vs-stderr
 Join the dark side!
 Hello from the other side!
 ```
@@ -24,7 +24,7 @@ Hello from the other side!
 Let us investigate using `strace`.
 
 ```console
-student@OS:~/.../demo/optimizations$ strace --trace=write ./stdout-vs-stderr
+student@os:~/.../demo/optimizations$ strace --trace=write ./stdout-vs-stderr
 write(2, "Join the ", 9Join the )                = 9
 write(2, "dark side!\n", 11dark side!
 )            = 11
@@ -37,7 +37,7 @@ This mechanism is called **buffering** and serves to reduce the number of `write
 Uncomment the `setvbuf()` function to stop the `stdout` buffering.
 
 ```console
-student@OS:~/.../demo/optimizations$ strace --trace=write ./stdout-vs-stderr
+student@os:~/.../demo/optimizations$ strace --trace=write ./stdout-vs-stderr
 write(1, "Hello ", 6Hello )                   = 6
 write(1, "from ", 5from )                    = 5
 write(1, "the ", 4the )                     = 4
@@ -53,14 +53,14 @@ write(2, "dark side!\n", 11dark side!
 We write **10000 bytes** to a file, **1 byte** at a time with `fwrite()` and use `strace` and `time` to benchmark this solution.
 
 ```console
-student@OS:~/.../demo/optimizations$ strace --trace=write ./fwrite-10000
+student@os:~/.../demo/optimizations$ strace --trace=write ./fwrite-10000
 write(3, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"..., 4096) = 4096
 write(3, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"..., 4096) = 4096
 write(3, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"..., 1808) = 1808
 ```
 
 ```console
-student@OS:~/.../demo/optimizations$ time ./fwrite-10000 
+student@os:~/.../demo/optimizations$ time ./fwrite-10000 
 real    0m0.001s
 user    0m0.001s
 sys     0m0.000s
@@ -74,14 +74,14 @@ The `write()` syscalls are triggered when buffer is full, thus reducing the numb
 We write **10000 bytes** to a file, **1 byte** at a time with `write()` and use `strace` and `time` to benchmark this solution.
 
 ```console
-student@OS:~/.../demo/optimizations$ strace -c --trace=write ./write-10000
+student@os:~/.../demo/optimizations$ strace -c --trace=write ./write-10000
 % time     seconds  usecs/call     calls    errors syscall
 ------ ----------- ----------- --------- --------- ----------------
 100.00    0.377586          37     10000           write
 ```
 
 ```console
-student@OS:~/.../demo/optimizations$ time ./write-10000 
+student@os:~/.../demo/optimizations$ time ./write-10000 
 real    0m0.011s
 user    0m0.001s
 sys     0m0.011s
@@ -94,14 +94,14 @@ This example serves as a comparison item for `fwrite` and `unbuffered write`.
 We write **1000 bytes** to a file, **1 byte** at a time with unbuffered `write()` and use `strace` and `time` to benchmark this solution.
 
 ```console
-student@OS:~/.../demo/optimizations$ strace -c --trace=write ./write-1000-unbuf
+student@os:~/.../demo/optimizations$ strace -c --trace=write ./write-1000-unbuf
 % time     seconds  usecs/call     calls    errors syscall
 ------ ----------- ----------- --------- --------- ----------------
 100.00    0.055044          55      1000           write
 ```
 
 ```console
-student@OS:~/.../demo/optimizations$ time ./write-1000-unbuf
+student@os:~/.../demo/optimizations$ time ./write-1000-unbuf
 real    0m2.052s
 user    0m0.000s
 sys     0m0.087s
@@ -118,7 +118,7 @@ It proceeds to encode the number and sends it to the server.
 After receiving a response it prints it and stops its execution.
 
 ```console
-student@OS:~/.../demo/optimizations$ python client.py localhost 1234 6
+student@os:~/.../demo/optimizations$ python client.py localhost 1234 6
 root: Connected to localhost:1234
 root: Sending 6
 function(6): 13
@@ -133,7 +133,7 @@ After configuring the server we start it in a loop and call `handle()` for each 
 The result is encoded and sent back to the client.
 
 ```console
-student@OS:~/.../demo/optimizations$ python server.py 1234
+student@os:~/.../demo/optimizations$ python server.py 1234
 root: Starting server on port 1234
 root: Received connection from ('127.0.0.1', 44834)
 root: Message: 6
@@ -156,7 +156,7 @@ See [server.py](#serverpy).
 This is a simple bash script that receives the port of a running server as argument and proceeds to run multiple **client.py** instances.
 
 ```console
-student@OS:~/.../demo/optimizations$ time ./client_bench.sh 1234
+student@os:~/.../demo/optimizations$ time ./client_bench.sh 1234
 root: Connected to localhost:1234
 root: Sending 30
 root: Connected to localhost:1234

--- a/content/chapters/io/lecture/slides/IPC.md
+++ b/content/chapters/io/lecture/slides/IPC.md
@@ -80,7 +80,7 @@
 - Stored on disk as a **special file**
 
 ```console
-student@OS:~$ ls -l my_fifo
+student@os:~$ ls -l my_fifo
 prw-r--r-- 1 student student 0 nov 22 18:38 my_fifo
 ```
 
@@ -241,7 +241,7 @@ prw-r--r-- 1 student student 0 nov 22 18:38 my_fifo
   - Client `connects` to the server using the file
 
 ```console
-student@OS:~/.../demo/IPC$ ls -l
+student@os:~/.../demo/IPC$ ls -l
 srwxrwxr-x 1 student student    0 dec  2 16:03 unix_socket
 ```
 

--- a/content/chapters/io/lecture/slides/optimizations.md
+++ b/content/chapters/io/lecture/slides/optimizations.md
@@ -15,7 +15,7 @@
 ### Investigate
 
 ```console
-student@OS:~/.../demo/optimizations$ ./stdout-vs-stderr 
+student@os:~/.../demo/optimizations$ ./stdout-vs-stderr 
 Join the dark side!
 Hello from the other side!
 ```
@@ -75,7 +75,7 @@ strace --trace=write ./stdout-vs-stderr
   - Enough time has passed since the last `write()`
 
 ```console
-student@OS:~$ cat /proc/sys/vm/dirty_expire_centisecs 
+student@os:~$ cat /proc/sys/vm/dirty_expire_centisecs 
 3000
 ```
 

--- a/content/chapters/software-stack/lab/content/app-investigate.md
+++ b/content/chapters/software-stack/lab/content/app-investigate.md
@@ -6,7 +6,7 @@ For now, we know that applications are developed using high-level languages and 
 Let's enter the `support/app-investigate/` folder and run the `get_app_types.sh` script:
 
 ```console
-student@so:~/.../lab/support/app-investigate$ ./get_app_types.sh
+student@os:~/.../lab/support/app-investigate$ ./get_app_types.sh
 binary apps: 2223
 Perl apps: 256
 Shell apps: 454
@@ -20,7 +20,7 @@ The output will differ between systems, given each has particular types of appli
 We list them by running the command inside the `get_app_types.sh` script:
 
 ```console
-student@so:~/.../lab/support/app-investigate$ find /usr/bin /bin /usr/sbin /sbin -type f -exec file {} \;
+student@os:~/.../lab/support/app-investigate$ find /usr/bin /bin /usr/sbin /sbin -type f -exec file {} \;
 [...]
 /usr/bin/qpdldecode: ELF 64-bit LSB shared object, x86-64 [...]
 /usr/bin/mimeopen: Perl script text executable


### PR DESCRIPTION
Use `student@os` consistently as part of the prompt in code snippets.