### PR TITLE
Fix trailing white spaces

### DIFF
--- a/content/chapters/app-interact/lab/content/os-cloud.md
+++ b/content/chapters/app-interact/lab/content/os-cloud.md
@@ -170,7 +170,7 @@ Now let's move inside the `os-cloud` container:
 
 ```console
 student@os:~/.../support/os-cloud$ docker-compose exec os-cloud bash
-root@89a986d2526e:/app# 
+root@89a986d2526e:/app#
 ```
 
 Since the virtual machines run inside this container, we should expect to see the one that we created in the previous step.
@@ -195,13 +195,13 @@ ED25519 key fingerprint is SHA256:3Mfa1fB9y4knUDJWEmEOTz9dWOE7SVhnH/kCBJ15Y0E.
 This key is not known by any other names
 Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
 Warning: Permanently added '192.168.0.2' (ED25519) to the list of known hosts.
-root@192.168.0.2's password: 
+root@192.168.0.2's password:
 Welcome to Ubuntu 22.04 LTS (GNU/Linux 5.15.0-40-generic x86_64)
 
 ...
 
 Last login: Thu Nov 17 07:49:55 2022
-root@ubuntu:~# 
+root@ubuntu:~#
 ```
 
 The vm is also accessible on the serial console (notice the `-serial telnet::10002,server,nowait` argument to qemu).
@@ -214,22 +214,22 @@ Connected to localhost.
 Escape character is '^]'.
 
 ubuntu login: root
-Password: 
+Password:
 Welcome to Ubuntu 22.04 LTS (GNU/Linux 5.15.0-40-generic x86_64)
 
 ...
 
 Last login: Thu Nov 17 07:50:11 UTC 2022 from 192.168.0.1 on pts/0
-root@ubuntu:~# 
+root@ubuntu:~#
 ```
 
 To exit the serial console press `CTRL+]`, then type `quit`:
 
 ```console
-root@ubuntu:~# 
+root@ubuntu:~#
 telnet> quit
 Connection closed.
-root@adf6e0bf4e6e:/app# 
+root@adf6e0bf4e6e:/app#
 ```
 
 ## (Even) More Implementation Details
@@ -275,7 +275,7 @@ Let's check the database contents (take the password from the `setup_db.sh` file
 
 ```console
 student@os:~/.../support/os-cloud$ docker-compose exec db mysql -u os-cloud -p os-cloud
-Enter password: 
+Enter password:
 ...
 MariaDB [os-cloud]> select * from vm;
 +----+-------+---------+------------+------------+-------------------+------------+----------+-------------------+------------------+-------+
@@ -370,9 +370,9 @@ student@os:~/.../support/os-cloud$ qemu-system-x86_64 -enable-kvm -m 2G -hda my-
 Ubuntu 22.04 LTS ubuntu ttyS0
 
 ubuntu login: root
-Password: 
+Password:
 ...
-root@ubuntu:~# 
+root@ubuntu:~#
 ```
 
 Here we can further run customization commands, like the ones in the `ubuntu_22_04_vm_prepare` function, or any other things that we want.

--- a/content/chapters/data/lab/content/process-memory.md
+++ b/content/chapters/data/lab/content/process-memory.md
@@ -473,7 +473,7 @@ brk(0x55ab98b08000)                     = 0x55ab98b08000
 write(1, "New allocation at 0x55ab98adfb10"..., 33New allocation at 0x55ab98adfb10
 ) = 33
 write(1, "Press key to deallocate ...", 27Press key to deallocate ...) = 27
-read(0, 
+read(0,
 "\n", 1024)                     = 1
 brk(0x55ab98b00000)                     = 0x55ab98b00000
 [...]
@@ -505,7 +505,7 @@ mmap(NULL, 266240, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7
 write(1, "New allocation at 0x7feee19b1010"..., 33New allocation at 0x7feee19b1010
 ) = 33
 write(1, "Press key to deallocate ...", 27Press key to deallocate ...) = 27
-read(0, 
+read(0,
 "\n", 1024)                     = 1
 munmap(0x7feee19b1000, 266240)          = 0
 [...]

--- a/content/chapters/data/lab/content/working-memory.md
+++ b/content/chapters/data/lab/content/working-memory.md
@@ -99,7 +99,7 @@ But even for programming languages that don't offer pointers (such as Python) is
 In the `str.py` file, we look to modify `str[1]`, but this fails:
 
 ```console
-student@os:~/.../lab/support/memory-protection$ ./str.py 
+student@os:~/.../lab/support/memory-protection$ ./str.py
 n, 110, n
 Traceback (most recent call last):
   File "./str.py", line 5, in <module>

--- a/content/chapters/io/lab/content/arena.md
+++ b/content/chapters/io/lab/content/arena.md
@@ -101,7 +101,7 @@ Now run the script **a few times** and compare the results.
 You should see some drastic improvements in the running times, such as:
 
 ```console
-student@os:/.../support/file-mappings$ ./benchmark_cp.sh 
+student@os:/.../support/file-mappings$ ./benchmark_cp.sh
 make: Nothing to be done for 'all'.
 Benchmarking mmap_cp on a 1 GB file...
 
@@ -115,7 +115,7 @@ user    0m0,013s
 sys     0m1,301s
 
 
-student@os:/.../support/file-mappings$ ./benchmark_cp.sh 
+student@os:/.../support/file-mappings$ ./benchmark_cp.sh
 make: Nothing to be done for 'all'.
 Benchmarking mmap_cp on a 1 GB file...
 

--- a/content/chapters/io/lab/content/file-mappings.md
+++ b/content/chapters/io/lab/content/file-mappings.md
@@ -25,13 +25,13 @@ student@os:~$ cat /proc/$(pidof sleep)/maps
 7fe443937000-7fe443985000 r--p 0019a000 103:07 6432810                   /usr/lib/x86_64-linux-gnu/libc-2.31.so
 7fe443985000-7fe443989000 r--p 001e7000 103:07 6432810                   /usr/lib/x86_64-linux-gnu/libc-2.31.so
 7fe443989000-7fe44398b000 rw-p 001eb000 103:07 6432810                   /usr/lib/x86_64-linux-gnu/libc-2.31.so
-7fe44398b000-7fe443991000 rw-p 00000000 00:00 0 
+7fe44398b000-7fe443991000 rw-p 00000000 00:00 0
 7fe4439ad000-7fe4439ae000 r--p 00000000 103:07 6429709                   /usr/lib/x86_64-linux-gnu/ld-2.31.so
 7fe4439ae000-7fe4439d1000 r-xp 00001000 103:07 6429709                   /usr/lib/x86_64-linux-gnu/ld-2.31.so
 7fe4439d1000-7fe4439d9000 r--p 00024000 103:07 6429709                   /usr/lib/x86_64-linux-gnu/ld-2.31.so
 7fe4439da000-7fe4439db000 r--p 0002c000 103:07 6429709                   /usr/lib/x86_64-linux-gnu/ld-2.31.so
 7fe4439db000-7fe4439dc000 rw-p 0002d000 103:07 6429709                   /usr/lib/x86_64-linux-gnu/ld-2.31.so
-7fe4439dc000-7fe4439dd000 rw-p 00000000 00:00 0 
+7fe4439dc000-7fe4439dd000 rw-p 00000000 00:00 0
 7ffd07aeb000-7ffd07b0c000 rw-p 00000000 00:00 0                          [stack]
 7ffd07b8b000-7ffd07b8e000 r--p 00000000 00:00 0                          [vvar]
 7ffd07b8e000-7ffd07b8f000 r-xp 00000000 00:00 0                          [vdso]

--- a/content/chapters/io/lab/content/io-internals.md
+++ b/content/chapters/io/lab/content/io-internals.md
@@ -15,8 +15,8 @@ Here are the most important fields in `struct _IO_FILE`:
 
 ```c
 struct _IO_FILE {
-        int fd;         /* File descriptor */      
-        
+        int fd;         /* File descriptor */
+
         unsigned flags; /* Flags with which `open()` was called */
 
         int mode;       /* File permissions; passed to `open()` */

--- a/content/chapters/io/lab/content/redirections.md
+++ b/content/chapters/io/lab/content/redirections.md
@@ -158,7 +158,7 @@ Compile and run the code, then inspect the resulting files.
 You'll notice they contain opposing strings:
 
 ```console
-student@os:~/.../lab/support/redirect$ cat redirect_stderr_file.txt 
+student@os:~/.../lab/support/redirect$ cat redirect_stderr_file.txt
 Message for STDOUT
 
 student@os:~/.../lab/support/redirect$ cat redirect_stdout_file.txt

--- a/content/chapters/io/lab/content/remote-io.md
+++ b/content/chapters/io/lab/content/remote-io.md
@@ -23,7 +23,7 @@ HTTP request sent, awaiting response... 200 OK
 Length: 1256 (1,2K) [text/html]
 Saving to: ‘index.html’
 
-index.html                                                           100%[====================================================================================================================================================================>]   1,23K  --.-KB/s    in 0s      
+index.html                                                           100%[====================================================================================================================================================================>]   1,23K  --.-KB/s    in 0s
 
 2022-12-02 15:53:31 (248 MB/s) - ‘index.html’ saved [1256/1256]
 ```
@@ -46,7 +46,7 @@ student@os:~$ cat index.html
         margin: 0;
         padding: 0;
         font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-        
+
     }
     div {
         width: 600px;
@@ -66,7 +66,7 @@ student@os:~$ cat index.html
             width: auto;
         }
     }
-    </style>    
+    </style>
 </head>
 
 <body>

--- a/content/chapters/io/lab/quiz/mmap-read-write-benchmark.md
+++ b/content/chapters/io/lab/quiz/mmap-read-write-benchmark.md
@@ -17,7 +17,7 @@ According to the times shown by `benchmark_cp.sh`, which of the two implementati
 In our case, running the script a few times results in the following running times:
 
 ```console
-student@os:/.../support/file-mappings$ ./benchmark_cp.sh 
+student@os:/.../support/file-mappings$ ./benchmark_cp.sh
 make: Nothing to be done for 'all'.
 Benchmarking mmap_cp on a 1GB file...
 
@@ -31,7 +31,7 @@ user    0m0,039s
 sys	0m2,469s
 
 
-student@os:/.../support/file-mappings$ ./benchmark_cp.sh 
+student@os:/.../support/file-mappings$ ./benchmark_cp.sh
 make: Nothing to be done for 'all'.
 Benchmarking mmap_cp on a 1 GB file...
 

--- a/content/chapters/io/lab/quiz/pipe-ends.md
+++ b/content/chapters/io/lab/quiz/pipe-ends.md
@@ -19,7 +19,7 @@ Which end of a pipe created by `pipe()` is for reading and which one is for writ
 Running the binary first tells us which file descriptor is which:
 
 ```console
-student@os:~/.../lab/support/pipes$ ./anonymous_pipes 
+student@os:~/.../lab/support/pipes$ ./anonymous_pipes
 pipedes[0] = 3; pipedes[1] = 4
  * pipe created
  -- Press ENTER to continue ...

--- a/content/chapters/io/lecture/demo/IPC/README.md
+++ b/content/chapters/io/lecture/demo/IPC/README.md
@@ -16,7 +16,7 @@ The parent will write at one end of the pipe and the child will read from the ot
 Expected output:
 
 ```console
-student@os:~/.../demo/IPC$ ./pipe 
+student@os:~/.../demo/IPC$ ./pipe
 I am the one who knocks!
 ```
 

--- a/content/chapters/io/lecture/demo/devices/README.md
+++ b/content/chapters/io/lecture/demo/devices/README.md
@@ -59,7 +59,7 @@ Read 100 bytes from /dev/sda:
 0000030 f1e2 18cd 5688 5500 46c6 0511 46c6 0010
 0000040 41b4 aabb cd55 5d13 0f72 fb81 aa55 0975
 0000050 c1f7 0001 0374 46fe 6610 8000 0001 0000
-0000060 0000 0000                              
+0000060 0000 0000
 0000064
 
 student@os:~/.../demo/devices$ sudo ./read-from-device.sh /dev/sda
@@ -70,7 +70,7 @@ Read 100 bytes from /dev/sda:
 0000030 f1e2 18cd 5688 5500 46c6 0511 46c6 0010
 0000040 41b4 aabb cd55 5d13 0f72 fb81 aa55 0975
 0000050 c1f7 0001 0374 46fe 6610 8000 0001 0000
-0000060 0000 0000                              
+0000060 0000 0000
 0000064
 ```
 
@@ -78,7 +78,7 @@ Char devices provide information in real-time so we expect a different output if
 Data from char devices are also used by the OS to collect randomness.
 
 ```console
-student@os:~/.../demo/devices$ ./read-from-device.sh /dev/urandom 
+student@os:~/.../demo/devices$ ./read-from-device.sh /dev/urandom
 Read 100 bytes from /dev/urandom:
 0000000 9672 15fc 6631 e9f7 6c6f 99c7 5504 e748
 0000010 6a18 6fa0 ffc1 fded b468 b5e9 8121 1187
@@ -86,10 +86,10 @@ Read 100 bytes from /dev/urandom:
 0000030 6bb5 5c77 b763 153e 79d3 b2ca 0715 6fec
 0000040 dc27 4acd bf69 1cf8 695e 3c1d a1e2 8234
 0000050 de59 9535 c344 9caa 55e3 a104 6d17 7e47
-0000060 65f3 3ad8                              
+0000060 65f3 3ad8
 0000064
 
-student@os:~/.../demo/devices$ ./read-from-device.sh /dev/urandom 
+student@os:~/.../demo/devices$ ./read-from-device.sh /dev/urandom
 Read 100 bytes from /dev/urandom:
 0000000 773c e9ff ba84 b7e8 9f76 bba9 6394 4023
 0000010 ddc3 4bd5 8777 5a8e 53a5 6532 1fbd 772a
@@ -97,6 +97,6 @@ Read 100 bytes from /dev/urandom:
 0000030 a6f6 f92f a906 929d e51d 3b8d 5cbf 2101
 0000040 fe00 6b07 0d6e 5739 32c0 c586 c289 eb27
 0000050 2a4e c817 497a 88c2 d128 9256 8880 4200
-0000060 9e8e 8710                              
+0000060 9e8e 8710
 0000064
 ```

--- a/content/chapters/io/lecture/demo/optimizations/README.md
+++ b/content/chapters/io/lecture/demo/optimizations/README.md
@@ -60,7 +60,7 @@ write(3, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"..., 1808) = 1808
 ```
 
 ```console
-student@os:~/.../demo/optimizations$ time ./fwrite-10000 
+student@os:~/.../demo/optimizations$ time ./fwrite-10000
 real    0m0.001s
 user    0m0.001s
 sys     0m0.000s
@@ -81,7 +81,7 @@ student@os:~/.../demo/optimizations$ strace -c --trace=write ./write-10000
 ```
 
 ```console
-student@os:~/.../demo/optimizations$ time ./write-10000 
+student@os:~/.../demo/optimizations$ time ./write-10000
 real    0m0.011s
 user    0m0.001s
 sys     0m0.011s

--- a/content/chapters/io/lecture/demo/optimizations/README.md
+++ b/content/chapters/io/lecture/demo/optimizations/README.md
@@ -153,7 +153,7 @@ See [server.py](#serverpy).
 
 ### client_bench.sh
 
-This is a simple bash script that receives the port of a running server as argument and proceeds to run multiple **client.py** instances.
+This is a simple bash script that receives the port of a running server as argument and proceeds to run multiple `client.py` instances.
 
 ```console
 student@os:~/.../demo/optimizations$ time ./client_bench.sh 1234

--- a/content/chapters/io/lecture/slides/devices.md
+++ b/content/chapters/io/lecture/slides/devices.md
@@ -160,7 +160,7 @@ static ssize_t read_zero(struct file *file, char __user *buf,
 	while (count) {
 		size_t chunk = min_t(size_t, count, PAGE_SIZE);
 		size_t left = clear_user(buf + cleared, chunk);
-		
+
 		cleared += chunk;
 		count -= chunk;
 	}

--- a/content/chapters/io/lecture/slides/optimizations.md
+++ b/content/chapters/io/lecture/slides/optimizations.md
@@ -15,7 +15,7 @@
 ### Investigate
 
 ```console
-student@os:~/.../demo/optimizations$ ./stdout-vs-stderr 
+student@os:~/.../demo/optimizations$ ./stdout-vs-stderr
 Join the dark side!
 Hello from the other side!
 ```
@@ -75,7 +75,7 @@ strace --trace=write ./stdout-vs-stderr
   - Enough time has passed since the last `write()`
 
 ```console
-student@os:~$ cat /proc/sys/vm/dirty_expire_centisecs 
+student@os:~$ cat /proc/sys/vm/dirty_expire_centisecs
 3000
 ```
 


### PR DESCRIPTION
Remove trailing white spaces in content files. This PR is built on top PR #177. I will rebase it once PR #177 is merged.