### PR TITLE
Ensure perf installation is correct

### DIFF
--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -31,6 +31,14 @@ RUN /init-scripts/install-dmd.sh
 # Use python3
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
+# Ensure correct perf
+# If a "perf not found" error happens, then we need to copy the perf installed
+# above to the correct directory. This directory changes based on the CPU.
+# This trick might not work for major versions (5->6, or 5->4).
+RUN  \
+    perf_kernel_version=$(perf 2>&1 | grep "WARNING: perf not found for kernel" | awk -F' ' '{printf $7}');  \
+    if [ -n "${perf_kernel_version}" ]; then cp -r "/usr/lib/linux-tools/5.15.0-60-generic" "/usr/lib/linux-tools/${perf_kernel_version}-generic"; fi
+
 # Create user student
 RUN useradd -ms /bin/bash student && echo "student:student" | chpasswd && usermod -aG sudo student
 USER student


### PR DESCRIPTION
Perf uses custom libraries depending on the host linux kernel version.
The version is checked at runtime which means that even though perf might work with the installed version, it will not find it.

To fix this we can copy it to the correct spot depending on the computer (we can also link it if you want).

This is a dirty fix, the correct fix would be to install the correct version right from the start.
As this might not always be possible, this would imply compiling perf from source (from the linux kernel).

GitHub-Fixes: #184