### PR TITLE
Remove unused code

### DIFF
--- a/content/chapters/software-stack/lab/support/basic-syscall/hello.asm
+++ b/content/chapters/software-stack/lab/support/basic-syscall/hello.asm
@@ -29,7 +29,3 @@ main:
     mov rdi, 0
     mov rax, 60
     syscall
-
-    xor rax, rax
-    leave
-    ret


### PR DESCRIPTION
Remove dead code after the `exit` syscall.