### PR TITLE
lab-setup: Fix newlines between aliases

### DIFF
--- a/content/misc/lab-setup.md
+++ b/content/misc/lab-setup.md
@@ -38,7 +38,11 @@ The possible options are: `software-stack`, `data`, `compute`, `io` and `app-int
 If you're using the OS-runner Docker container, you can use the following shortcuts:
 
 `go-ss`       - changes directory to Software Stack lab
+
 `go-data`     - changes directory to Data lab
+
 `go-compute`  - changes directory to Compute lab
+
 `go-io`       - changes directory to IO lab
+
 `go-appInt`   - changes directory to App Interaction lab


### PR DESCRIPTION
Fix for the alias section in [Setting up the Lab Environment](https://open-education-hub.github.io/operating-systems/Lab/Setting%20up%20the%20Lab%20Environment/lab-setup) not displaying the newlines properly.