### PR TITLE
Update ltrace version in os-runner docker image.

### DIFF
--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -2,16 +2,21 @@ FROM ubuntu:20.04 AS ltrace-builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update && apt-get install -y build-essential git automake autoconf libtool libelf-dev
+# hadolint ignore=DL3008
+RUN apt-get -y update && apt-get install --no-install-recommends -y \
+    build-essential git automake autoconf libtool libelf-dev ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /build
-RUN git clone https://gitlab.com/cespedes/ltrace.git /build/ltrace
+RUN mkdir /build && \
+    git clone https://gitlab.com/cespedes/ltrace.git /build/ltrace
 
 WORKDIR /build/ltrace
 
-RUN git checkout 5cffc0d2134f697fbac8627ec5b5f0085cd47c8a
-
-RUN ./autogen.sh && ./configure --prefix=/usr --sysconfdir=/etc && make && make install
+RUN git checkout 5cffc0d2134f697fbac8627ec5b5f0085cd47c8a \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr --sysconfdir=/etc \
+    && make \
+    && make install
 
 
 FROM ubuntu:20.04

--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -1,3 +1,19 @@
+FROM ubuntu:20.04 AS ltrace-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && apt-get install -y build-essential git automake autoconf libtool libelf-dev
+
+RUN mkdir /build
+RUN git clone https://gitlab.com/cespedes/ltrace.git /build/ltrace
+
+WORKDIR /build/ltrace
+
+RUN git checkout 5cffc0d2134f697fbac8627ec5b5f0085cd47c8a
+
+RUN ./autogen.sh && ./configure --prefix=/usr --sysconfdir=/etc && make && make install
+
+
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -39,5 +55,8 @@ WORKDIR /home/student
 # Customize .bashrc
 COPY config_terminal.sh /init-scripts/config_terminal.sh
 RUN cat /init-scripts/config_terminal.sh >> ~/.bashrc
+
+# Install our own compiled version of ltrace
+COPY --from=ltrace-builder /usr/bin/ltrace /usr/bin/ltrace
 
 ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
This fixes #183 by using a newer version of `ltrace`. Since there's no newer version of `ltrace` available in `apt`, we have to compile it ourselves