### PR TITLE
Increase connect-timeout in dmd install script

### DIFF
--- a/util/os-runner/Dockerfile
+++ b/util/os-runner/Dockerfile
@@ -1,3 +1,19 @@
+FROM ubuntu:20.04 AS ltrace-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && apt-get install -y build-essential git automake autoconf libtool libelf-dev
+
+RUN mkdir /build
+RUN git clone https://gitlab.com/cespedes/ltrace.git /build/ltrace
+
+WORKDIR /build/ltrace
+
+RUN git checkout 5cffc0d2134f697fbac8627ec5b5f0085cd47c8a
+
+RUN ./autogen.sh && ./configure --prefix=/usr --sysconfdir=/etc && make && make install
+
+
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -39,5 +55,8 @@ WORKDIR /home/student
 # Customize .bashrc
 COPY config_terminal.sh /init-scripts/config_terminal.sh
 RUN cat /init-scripts/config_terminal.sh >> ~/.bashrc
+
+# Install our own compiled version of ltrace
+COPY --from=ltrace-builder /usr/bin/ltrace /usr/bin/ltrace
 
 ENTRYPOINT [ "bash" ]

--- a/util/os-runner/install-dmd.sh
+++ b/util/os-runner/install-dmd.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-curl -fsS https://dlang.org/install.sh | bash -s dmd
+curl -fsS https://dlang.org/install.sh | sed 's/--connect-timeout 5/--connect-timeout 15/g' | bash -s dmd
 # shellcheck source=/dev/null
 source "$(find ~/dlang -maxdepth 1 -name 'dmd-*')/activate"


### PR DESCRIPTION
This changes the `--connect-timeout 5` parameter passed to `curl` in the script from https://dlang.org/install.sh. It increases it from 5 to 15 seconds. In some cases (on my machine for example, for reasons unknown) it takes about 6 seconds, causing the entire script to fail and therefore the docker build process.