### PR TITLE
Increase connect-timeout in dmd install script

### DIFF
--- a/util/os-runner/install-dmd.sh
+++ b/util/os-runner/install-dmd.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-curl -fsS https://dlang.org/install.sh | bash -s dmd
+curl -fsS https://dlang.org/install.sh | sed 's/--connect-timeout 5/--connect-timeout 15/g' | bash -s dmd
 # shellcheck source=/dev/null
 source "$(find ~/dlang -maxdepth 1 -name 'dmd-*')/activate"


### PR DESCRIPTION
This changes the `--connect-timeout 5` parameter passed to `curl` in the script from https://dlang.org/install.sh. It increases it from 5 to 15 seconds. In some cases (on my machine for example, for reasons unknown) it takes about 6 seconds, causing the entire script to fail and therefore the docker build process as well.