### PR TITLE
workflows: Add GITHUB_TOKEN env in checkpatch.yml

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -20,3 +20,5 @@ jobs:
         git log --oneline --graph
     - name: Run checkpatch review
       uses: webispy/checkpatch-action@v9
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, the `checkpatch` workflow doesn't do any checking. This commit adds a `GITHUB_TOKEN` configuration to fix this and make `checkpatch` work.