### PR TITLE
Set ALLOC_SIZE_KB value to 64

### DIFF
--- a/content/chapters/data/lab/support/alloc-size/alloc_size.c
+++ b/content/chapters/data/lab/support/alloc-size/alloc_size.c
@@ -6,7 +6,7 @@
 #include "utils/utils.h"
 
 #define NUM_STEPS	10
-#define ALLOC_SIZE_KB	8
+#define ALLOC_SIZE_KB	64
 #define ALLOC_SIZE	(ALLOC_SIZE_KB * 1024)
 
 static void wait_for_input(const char *msg)


### PR DESCRIPTION
Changing ALLOC_SIZE_KB to 8 because there is no `brk()` call with this value.

When you start the program `./alloc_size` and investigate it with `pmap`, one can already notice that the heap has 132K already allocated.
```
~/Documents/operating-systems-work/content/chapters/data/lab/support/alloc-size (fix-alloc-size-kb-value ✗) pmap $(pidof alloc_size)
13764:   ./alloc_size
000055eede2e6000      4K r---- alloc_size
000055eede2e7000      4K r-x-- alloc_size
000055eede2e8000      4K r---- alloc_size
000055eede2e9000      4K r---- alloc_size
000055eede2ea000      4K rw--- alloc_size
000055eedfd7b000    132K rw---   [ anon ]
00007f6445ed9000    136K r---- libc-2.31.so
00007f6445efb000   1504K r-x-- libc-2.31.so
```

Because NUM_STEPS * ALLOC_SIZE_KB < initial heap size, there is going to be no `brk()` call. This can also be verified by inspecting with `strace`.

So, the students are not observing anything during this exercise.

I changed the size to be 64K and to generate some `brk()` calls and demonstrate memory leaks.