### PR TITLE
infra/cpplint: Ignore whitespace-semicolon

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,6 +1,7 @@
 filter=-whitespace/tab
 filter=-whitespace/line-length
 filter=-whitespace/braces
+filter=-whitespace/semicolon
 filter=-legal/copyright
 filter=-whitespace/comments
 filter=-build/header_guard


### PR DESCRIPTION
Filter out `whitespace-semicolon` warning for `cpplint`. This complains about semicolon-only lines (`;`) that are used in loops.