### PR TITLE
util/os-runner: Add colored help menu to makefile

### DIFF
--- a/util/os-runner/Makefile
+++ b/util/os-runner/Makefile
@@ -9,13 +9,13 @@ HOSTNAME="os"
 pull:
 	docker pull $(OS_IMAGE)
 
-docker-image:
+docker-image: ## Build the docker image.
 ifeq ("$(shell docker images -q $(OS_LOCAL_IMAGE))", "")
 	docker buildx build --platform linux/amd64 -t $(OS_LOCAL_IMAGE) .
 endif
 
 
-start: pull
+start: pull ## Start the container in the background if it is not already running.
 ifneq ("$(shell docker container inspect -f '{{.State.Running}}' os-runner)", "true")
 	docker run	\
 		--detach	\
@@ -28,9 +28,24 @@ ifneq ("$(shell docker container inspect -f '{{.State.Running}}' os-runner)", "t
 endif
 
 
-attach: start
+attach: start ## Attach to the container.
 	docker exec -it $(OS_CONTAINER) bash
 
-clean:
+clean: ## Stop and remove the container.
 	docker container stop $(OS_CONTAINER)
 	docker container rm $(OS_CONTAINER)
+
+help: ## Show this help menu and exit.
+	@awk 'BEGIN {	\
+		FS = ":.*##";	\
+		printf "OS class container environment.\n\n";	\
+		printf "\033[1mUSAGE\033[0m\n";	\
+		printf "  make [VAR=... [VAR=...]] \033[36mTARGET\033[0m\n\n";	\
+		printf "\033[1mTARGETS\033[0m\n";	\
+	}	\
+	/^[a-zA-Z_-]+:.*?##/ {	\
+		printf "  \033[36m%-23s\033[0m %s\n", $$1, $$2	\
+	}	\
+	/^##@/ {	\
+		printf "\n\033[1m%s\033[0m\n", substr($$0, 5)	\
+	} ' $(MAKEFILE_LIST)

--- a/util/os-runner/README.md
+++ b/util/os-runner/README.md
@@ -47,6 +47,8 @@ This is an isolated environment to run the examples and tasks from laboratories 
 
 - `make start` - Start `OS-runner` container
 
-- `make attach`   - Attach a new session to `OS-runner` container, this is useful for tasks requiring multiple terminals
+- `make attach` - Attach a new session to `OS-runner` container, this is useful for tasks requiring multiple terminals
 
 - `make clean` - Stop `OS-runner` container and delete it
+
+- `make help` - Print usable Makefile commands


### PR DESCRIPTION
Add help menu to the `os-runner` Makefile.

![image](https://user-images.githubusercontent.com/46280801/228026099-8555e2b7-5ec7-4a36-8c46-e89772d539b4.png)
