### PR TITLE
infra/labeler: Change `kind/improvement` to `kind/improve`

### DIFF
--- a/.github/scripts/add-labels.js
+++ b/.github/scripts/add-labels.js
@@ -21,7 +21,7 @@ async function createLabelsForPR(github, context, pr) {
                 addLabelToList(labels, 'kind/new')
             }
             else if (file.status === 'modified' && file.deletions === 0 && file.additions > 0) {
-                addLabelToList(labels, 'kind/improvement')
+                addLabelToList(labels, 'kind/improve')
             }
         })
     })


### PR DESCRIPTION
The `add-labels.js` script was wrongly assigning the label `kind/improvement` instead of `kind/improve`. This fixes the issue.

Fixes #236.