### PR TITLE
compute/lecture: Fix typo from `thread` to `process`

### DIFF
--- a/content/chapters/compute/lecture/slides/processes.md
+++ b/content/chapters/compute/lecture/slides/processes.md
@@ -60,7 +60,10 @@
 * threads
 
 ```console
-student@os:~/.../compute/lecture/demo/create-thread$ python3 create_process.py
-[main] PID = 16066; PPID = 7820
-[thread] PID = 16066; PPID = 7820
+student@os:~/.../compute/lecture/demo/create-process$ python3 create_process.py
+[parent] PID = 186411
+[parent] Before starting, child PID = None
+[parent] After starting, child PID = 186412
+[child] PID = 186412; PPID = 186411
+[child] Message from parent: OS Rullz!
 ```


### PR DESCRIPTION
The demo was referring to process, not thread attributes.

Fixes #233.