### PR TITLE
assignments/mini-libc: Use `errno` in implementation of `write()` and `read()`

### DIFF
--- a/content/assignments/mini-libc/src/io/read_write.c
+++ b/content/assignments/mini-libc/src/io/read_write.c
@@ -3,13 +3,28 @@
 #include <internal/io.h>
 #include <internal/syscall.h>
 #include <internal/types.h>
+#include <errno.h>
 
 ssize_t write(int fd, const void *buf, size_t len)
 {
-	return syscall(__NR_write, fd, buf, len);
+	int ret = syscall(__NR_write, fd, buf, len);
+
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	return ret;
 }
 
 ssize_t read(int fd, void *buf, size_t len)
 {
-	return syscall(__NR_read, fd, buf, len);
+	int ret =  syscall(__NR_read, fd, buf, len);
+
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	return ret;
 }


### PR DESCRIPTION
Fixes #232 