### PR TITLE
Add an indication to build a static executable

### DIFF
--- a/content/chapters/data/lab/content/process-memory.md
+++ b/content/chapters/data/lab/content/process-memory.md
@@ -263,8 +263,9 @@ For now, we want to point out how threads affect the process memory layout.**
 
 ### Practice
 
-1. Build the multithreaded program as a static executable.
+1. Build the multithreaded program as a static executable by adding `LDFLAGS = -static` to the Makefile:
    Run it.
+   You can check the executable is statically linked by executing the command `ldd multithreaded`.
    Notice the same effect of the thread creation on the process memory layout: the creation of a new stack of `8192 KB`.
 
 1. Make a program in another language of your choice that creates threads.

--- a/content/common/makefile/defs.mk
+++ b/content/common/makefile/defs.mk
@@ -8,6 +8,6 @@ LOGGER_DIR := $(UTILS_DIR)/log
 
 CPPFLAGS += -I$(INCLUDES_DIR)
 CFLAGS += -g -Wall -Wextra
-LDFLAGS = -z lazy
+LDFLAGS += -z lazy
 LOGGER_OBJ = log.o
 LOGGER = $(LOGGER_DIR)/$(LOGGER_OBJ)

--- a/content/common/makefile/defs.mk
+++ b/content/common/makefile/defs.mk
@@ -8,5 +8,6 @@ LOGGER_DIR := $(UTILS_DIR)/log
 
 CPPFLAGS += -I$(INCLUDES_DIR)
 CFLAGS += -g -Wall -Wextra
+LDFLAGS = -z lazy
 LOGGER_OBJ = log.o
 LOGGER = $(LOGGER_DIR)/$(LOGGER_OBJ)

--- a/content/common/makefile/single.mk
+++ b/content/common/makefile/single.mk
@@ -1,5 +1,3 @@
-LDFLAGS = -z lazy
-
 all: $(BINARY)
 
 # Get the relative path to the directory of the current makefile.


### PR DESCRIPTION
Add an indication to configure LDFLAGS to create a static executable.

Also, move LDFLAGS to `defs.mk`.