### PR TITLE
util/super-linter: Add interactive option

### DIFF
--- a/util/super-linter.sh
+++ b/util/super-linter.sh
@@ -2,10 +2,14 @@
 
 # PATH_TO_CODEBASE: The path to the codebase you want to lint. Don't use relative paths.
 # PATH_TO_LINT_RULES: The path to the lint rules you want to use. Don't use relative paths.
+# OPTIONS:
+#  -i enters the super-linter container
+
 # Example: ./super-linter.sh /path/to/codebase/to/be/check /path/to/.github/workflows from the root of the repo
 
 PATH_TO_CODEBASE=$(realpath "$1")
 PATH_TO_LINT_RULES=$(realpath "$2")
+OPTIONS=""
 
 # Exit if codebase is not provided.
 if [ -z "$PATH_TO_CODEBASE" ]; then
@@ -19,12 +23,20 @@ if [ -z "$PATH_TO_LINT_RULES" ]; then
   exit 1
 fi
 
+if [ "$3" == "-i" ]; then
+  OPTIONS="-it --entrypoint bash"
+elif [ -n "$3" ]; then
+  echo "Unrecognized option $3"
+  exit 1
+fi
+
 # Exit if docker is not installed.
 if ! [ -x "$(command -v docker)" ]; then
   echo 'Error: docker is not installed.' >&2
   exit 1
 fi
 
+# shellcheck disable=SC2086
 docker run --rm \
     -e RUN_LOCAL=true \
     -e VALIDATE_GITHUB_ACTIONS=false \
@@ -36,4 +48,5 @@ docker run --rm \
     -e LOG_LEVEL=WARN \
     -v "$PATH_TO_LINT_RULES":/tmp/github \
     -v "$PATH_TO_CODEBASE":/tmp/lint \
+    $OPTIONS \
     github/super-linter:v4


### PR DESCRIPTION
Add "-i" flag to start the super-linter container in interactive mode, with bash as entrypoint.