### PR TITLE
compute/lecture: Swap "Scheduling" and "Synchronization" sections

### DIFF
--- a/content/chapters/compute/lecture/slides.mdpp
+++ b/content/chapters/compute/lecture/slides.mdpp
@@ -27,6 +27,10 @@ revealOptions:
 
 !INCLUDE "slides/copy-on-write.md"
 
+!INCLUDE "slides/scheduling.md"
+
+!INCLUDE "slides/scheduling-algorithms.md"
+
 !INCLUDE "slides/synchronization.md"
 
 !INCLUDE "slides/mutual-exclusion.md"
@@ -36,9 +40,5 @@ revealOptions:
 !INCLUDE "slides/barrier.md"
 
 !INCLUDE "slides/thread-safety.md"
-
-!INCLUDE "slides/scheduling.md"
-
-!INCLUDE "slides/scheduling-algorithms.md"
 
 !INCLUDE "slides/cool-extra-stuff.md"


### PR DESCRIPTION
The "Synchronization" section refers to thread states when comparing mutexes and busy waiting for example, so it makes more sense to place The "Scheduling" section (where these concepts are presented) first.