### PR TITLE
infra: Disable `build/include_subdir` in `CPPLINT.cfg`

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -9,4 +9,5 @@ filter=-readability/multiline_comment
 filter=-readability/casting
 filter=-runtime/int
 filter=-runtime/printf
+filter=-build/include_subdir
 linelength=120


### PR DESCRIPTION
This is a warning related to using a subdirectory when including a local header file. Unfortunately, this often gets to including `./test.h` which is ugly and uncommon. Disable it.