### PR TITLE
data/lab: Add warning about running `benchmark_cp.sh`

### DIFF
--- a/content/chapters/data/lab/content/process-memory.md
+++ b/content/chapters/data/lab/content/process-memory.md
@@ -537,6 +537,9 @@ student@os:~/.../lab/support/copy$ make
 
 Run the `benchmark_cp.sh` script:
 
+Run the script in your local environment, not in the Docker container.
+Docker does not have permission to write to `/proc/sys/vm/drop_caches` file.
+
 ```console
 student@os:~/.../lab/support/copy$ ./benchmark_cp.sh
 Benchmarking mmap_copy on in.dat

--- a/content/chapters/data/lab/support/copy/benchmark_cp.sh
+++ b/content/chapters/data/lab/support/copy/benchmark_cp.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+# [WARNING]
+# This script should be run from local environment
+# The Docker container does not have permission to write to `/proc/sys/vm/_drop_caches`
+
 # Drop all OS caches: buffer cache, dentry cache, inode cache, page cache.
 sudo sh -c "sync; echo 3 > /proc/sys/vm/drop_caches"
 


### PR DESCRIPTION
Added a note in the `benchmark_cp.sh` script to warn the users to run the script from local environment.
The Docker container does not have permission to write to `/proc/sys/vm/drop_caches`.
This PR resolves #261.

Signed-off-by: Iulian Tăiatu <iulian27_marius@yahoo.com>