### PR TITLE
asg/mem-alloc: Restrictions on size field

### DIFF
--- a/content/assignments/memory-allocator/README.md
+++ b/content/assignments/memory-allocator/README.md
@@ -110,6 +110,9 @@ typedef struct block_meta {
 
 _Note_: Both the `struct block_meta` and the payload of a block should be aligned to **8 bytes**.
 
+_Note_: The checker uses the `size` from `struct block_meta`.
+Use `size` to store the **aligned size of the payload**.
+
 _Note_: Most compilers will automatically pad the structure, but you should still align it for portability.
 
 ![memory-block](./assets/memory-block.svg)


### PR DESCRIPTION
The checker uses the size field from struct block_meta and assumes it contains the aligned size of the payload.
Add this information to the assignment statement.