### PR TITLE
config: Remove `readability/todo` filter from `cpplint`

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -9,4 +9,5 @@ filter=-readability/multiline_comment
 filter=-readability/casting
 filter=-runtime/int
 filter=-runtime/printf
+filter=-readability/todo
 linelength=120


### PR DESCRIPTION
This filter forces all `TODO`s to be formatted like so `TODO(someone or a bug): ...`. This does not match our `TODO`s, which indicate code that students must fill in.