### PR TITLE
compute/lab: Remove `with event`

### DIFF
--- a/content/chapters/compute/lab/content/synchronization.md
+++ b/content/chapters/compute/lab/content/synchronization.md
@@ -189,7 +189,7 @@ If `notify()` is called before any thread has called `wait()`, the first thread 
 But this is not all, unfortunately.
 Look at the code in `support/apache2-simulator/apache2_simulator_condition.py`.
 See the main thread call `notify()` once it reads the message.
-Notice that this call is within a `with event`: so it acquires some mutex / semaphore.
+Notice that this call is preceded by an `acquire()` call, and succedeed by a `release()` call.
 
 `acquire()` and `release()` are commonly associated with mutexes or semaphores.
 What do they have to do with condition variables?
@@ -211,9 +211,9 @@ The mutex is used to access and modify the `messages` list atomically.
 Now you might be thinking that this code causes a deadlock:
 
 ```Python
-with event:
-    while len(messages) == 0:
-        event.wait()
+event.acquire()
+while len(messages) == 0:
+    event.wait()
 ```
 
 The thread gets the lock and then, if there are no messages, it switches its state to WAITING.

--- a/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_condition.py
+++ b/content/chapters/compute/lab/support/apache2-simulator/apache2_simulator_condition.py
@@ -13,15 +13,16 @@ def worker(event, id):
     msg = ""
 
     while True:
-        with event:
-            while len(messages) == 0:
-                event.wait()
+        event.acquire()
+        while len(messages) == 0:
+            event.wait()
 
-            print(f"Worker {id} started handling message...")
-            sleep(randint(1, 5))
+        print(f"Worker {id} started handling message...")
+        sleep(randint(1, 5))
 
-            msg = messages[0]
-            messages.pop(0)
+        msg = messages[0]
+        messages.pop(0)
+        event.release()
 
         print(f"Worker {id} handling message: {msg}")
         sleep(randint(1, 5))
@@ -48,13 +49,10 @@ def main():
         if msg == "exit":
             break
 
-        # Equivalent to:
-        #   event.acquire()
-        #   messages.append(msg)
-        #   event.release()
-        with event:
-            messages.append(msg)
-            event.notify()
+        event.acquire()
+        messages.append(msg)
+        event.notify()
+        event.release()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace `with event:` with the equivalent `acquire() and `release()` calls.

Closes #131 