### PR TITLE
compute/lab: Add minor and major page fault task

### DIFF
--- a/content/chapters/compute/lab/content/arena.md
+++ b/content/chapters/compute/lab/content/arena.md
@@ -239,3 +239,58 @@ The code in `test.c` verifies its single-threaded correctness, while the one in 
 Your task is to synchronize this data structure using whichever primitives you like.
 Try to keep the implementation efficient.
 Aim to decrease your running times as much as you can.
+
+## Minor and Major Page Faults
+
+The code in `support/page-faults/page_faults.c` generates some minor and major page faults.
+Open 2 terminals: one in which you will run the program, and one which will monitor the page faults of the program.
+In the monitoring terminal, run the following command:
+
+```console
+watch -n 1 'ps -eo min_flt,maj_flt,cmd | grep ./page_faults | head -n 1'
+```
+
+Compile the program and run it in the other terminal.
+You must press `enter` one time, before the program will prompt you to press `enter` more times.
+Watch the first number on the monitoring terminal;
+it increases.
+Those are the minor page faults.
+
+### Minor Page Faults
+
+A minor page fault is generated whenever a requested page is present in the physical memory, as a frame, but that frame isn't allocated to the process generating the request.
+These types of page faults are the most common, and they happen when calling functions from dynamic libraries, allocating heap memory, loading programs, reading files that have been cached, and many more situations.
+Now back to the program.
+
+The monitoring command already starts with some minor page faults, generated when loading the program.
+
+After pressing `enter`, the number increases, because a function from a dynamic library (libc) is fetched when the first `printf()` is executed.
+Subsequent calls to functions that are in the same memory page as `printf()` won't generate other page faults.
+
+After allocating the 100 Bytes, you might not see the number of page faults increase.
+This is because the "bookkeeping" data allocated by `malloc()` was able to fit in an already mapped page.
+The second allocation, the 1GB one, will always gnereate one minor page fault - for the bookkeeping data about the allocated memory zone.
+Notice that not all the pages for the 1GB are allocated.
+They are allocated - and generate page faults - when modified.
+By now you should know that this mechanism is called [copy-on-write](copy-on-write.md).
+
+Continue with pressing `enter` and observing the effects util you reach opening `file.txt`.
+
+Note that neither opening a file, getting information about it, nor mapping it in memory using `mmap()`, generate page faults.
+Also note the `posix_fadvise()` call after the one to `fstat()`.
+With this call we force the OS to not cache the file, so we can generate a **major page fault**.
+
+### Major Page Faults
+
+Major page faults happen when a page is requested, but it isn't present in the physical memory.
+These types of page faults happen in 2 situations:
+
+* a page that was swapped out (to the disk), due to lack of memory, is now accessed - this case is harder to show
+* the OS needs to read a file from the disk, because the file contents aren't present in the cache - the case we are showing now
+
+Press `enter` to print the file contents.
+Note the second number go up in the monitoring terminal.
+
+Comment the `posix_fadvise()` call, recompile the program, and run it again.
+You won't get any major page fault, because the file contents are cached by the OS, to avoid those page faults.
+As a rule, the OS will avoid major page faults whenever possible, because they are very costly in terms of running time.

--- a/content/chapters/compute/lab/content/copy-on-write.md
+++ b/content/chapters/compute/lab/content/copy-on-write.md
@@ -48,6 +48,8 @@ student@os:~/.../lab/support/fork-faults$ ps -o min_flt,maj_flt -p $(pidof fork_
 
 It will show you the number of minor and major page faults performed by the `fork_faults` process and its child.
 
+To better understand minor and major page faults, go through the [Minor and Major Page Faults](arena.md#minor-and-major-page-faults) excercise in Arena.
+
 [Quiz 1](../quiz/parent-faults-before-fork.md)
 
 Note that after `fork()`-ing, there is a second row in the output of `ps`.

--- a/content/chapters/compute/lab/support/page-faults/.gitignore
+++ b/content/chapters/compute/lab/support/page-faults/.gitignore
@@ -1,0 +1,2 @@
+page_faults
+file.txt

--- a/content/chapters/compute/lab/support/page-faults/Makefile
+++ b/content/chapters/compute/lab/support/page-faults/Makefile
@@ -1,0 +1,5 @@
+BINARIES = page_faults file.txt
+include ../../../../../common/makefile/multiple.mk
+
+file.txt:
+	curl metaphorpsum.com/paragraphs/20/50 > $@

--- a/content/chapters/compute/lab/support/page-faults/page_faults.c
+++ b/content/chapters/compute/lab/support/page-faults/page_faults.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+#include "utils/utils.h"
+
+int main(void)
+{
+	char *a, *b;
+	char filename[] = "file.txt";
+	int fd;
+	struct stat filestat;
+	char *data;
+
+	getchar();
+
+	printf("Press enter to allocate 100 Bytes\n");
+	getchar();
+
+	a = malloc(100);
+	DIE(a == NULL, "malloc");
+
+	printf("Press enter to allocate 1GB\n");
+	getchar();
+
+	b = malloc(1 * 1024 * 1024 * 1024);
+	DIE(b == NULL, "malloc");
+
+	printf("Press enter to write a[50]\n");
+	getchar();
+
+	a[50] = 1;
+
+	printf("Press enter to write every byte in b\n");
+	getchar();
+
+	for (int i = 0; i < 1 * 1024 * 1024 * 1024; i++)
+		b[i] = 0;
+
+	printf("Press enter to free a and b\n");
+	getchar();
+
+	free(a);
+	free(b);
+
+	printf("Press enter to open \"file.txt\"\n");
+	getchar();
+
+	fd = open(filename, O_RDONLY);
+	DIE(fd < 0, "open");
+
+	printf("Press enter to get file size\n");
+	getchar();
+
+	DIE(fstat(fd, &filestat) != 0, "fstat");
+	DIE(posix_fadvise(fd, 0, filestat.st_size, POSIX_FADV_DONTNEED) != 0, "posix_fadvise");
+
+
+	printf("Press enter to map file into memory\n");
+	getchar();
+
+	data = mmap(NULL, filestat.st_size, PROT_READ, MAP_SHARED, fd, 0);
+	DIE(data == MAP_FAILED, "mmap");
+
+	printf("Press enter to print file contents\n");
+	getchar();
+
+	printf("%s\n", data);
+
+	printf("Press enter to close file\n");
+	getchar();
+
+	munmap(data, filestat.st_size);
+	close(fd);
+
+	printf("Press enter to exit\n");
+	getchar();
+
+	return 0;
+}


### PR DESCRIPTION
To force a major page fault, I/O reads are forced. Getting swap-ins and outs would be another way, but it is more difficult.

Closes #129 