### PR TITLE
`compute/lab`: Added third argument for strtok_r in mini-shell.c

### DIFF
--- a/content/chapters/compute/lab/support/mini-shell/mini_shell.c
+++ b/content/chapters/compute/lab/support/mini-shell/mini_shell.c
@@ -39,6 +39,7 @@ static int parse_line(char *line)
 	int idx = 0;
 	char *token;
 	char *delim = "=\n";;
+	char *saveptr = NULL;
 
 	stdin_file = NULL;
 	stdout_file = NULL;
@@ -50,7 +51,7 @@ static int parse_line(char *line)
 
 	/* Normal command. */
 	delim = " \t\n";
-	token = strtok_r(line, delim);
+	token = strtok_r(line, delim, &saveptr);
 
 	if (token == NULL)
 		return ERROR;
@@ -66,7 +67,7 @@ static int parse_line(char *line)
 		}
 
 		args[idx++] = strdup(token);
-		token = strtok_r(NULL, delim);
+		token = strtok_r(NULL, delim, &saveptr);
 	}
 
 	args[idx++] = NULL;


### PR DESCRIPTION
Hello,
I noticed that the `mini-shell.c` file used in the Arena subchapter of the Compute section had an issue regarding the calls to `strtok_r` used to parse input from the user which caused it to not compile. The calls only used 2 arguments, as if it was `strtok` which was called. I added the third parameter, `&saveptr`, in order to properly call `strtok_r`.