### PR TITLE
`infra/cpplint`: Disable `include_subdir`

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -10,4 +10,5 @@ filter=-readability/casting
 filter=-runtime/int
 filter=-runtime/printf
 filter=-readability/todo
+filter=-build/include_subdir
 linelength=120


### PR DESCRIPTION
Remove the check for directory name in include directives from `cpplint`.