### PR TITLE
workflows: Add PR deployment action

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -1,0 +1,64 @@
+name: OpenEduHub - PR Deployment
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  deploy:
+    if: ${{ github.event.label.name == 'needs-rendering' }}
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ./repo
+      - run: |
+          cd repo
+          REF=$(echo ${{ github.event.number }} | sed 's/\//\\\//g')
+          sed -i "s/baseUrl: \/operating-systems\//baseUrl: \/operating-systems\/$REF\//" config.yaml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./repo
+          file: ./repo/Dockerfile
+          push: false
+          load: true
+          tags: operating-systems/docusaurus:latest
+          cache-from: type=gha
+          cache-to: type=gha
+
+      - name: Load Image
+        run: |
+          mkdir -p ${{ github.event.number }}
+          docker image list
+          docker run -v $GITHUB_WORKSPACE/repo:/content -v $GITHUB_WORKSPACE/${{ github.event.number }}:/output operating-systems/docusaurus:latest
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages-pr` branch:
+          publish_dir: ./${{ github.event.number }}
+          destination_dir: ${{ github.event.number }}
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          publish_branch: gh-pages
+
+      - name: Add Comment to PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Published at http://open-education-hub.github.io/operating-systems/${{ github.event.number }}/


### PR DESCRIPTION
The action builds the rendered website and pushes it to the `gh-pages` in a directory named after the PR number: `refs/pull/<number>/merge`. It then publishes a message containing the link where the website may be inspected.

I tested the action here: https://github.com/teodutu/operating-systems/pull/8#issuecomment-1739160737