### PR TITLE
`asgn/mini-libc`: Use consistent spacing for TODOs

### DIFF
--- a/content/assignments/mini-libc/src/string/string.c
+++ b/content/assignments/mini-libc/src/string/string.c
@@ -5,28 +5,24 @@
 char *strcpy(char *destination, const char *source)
 {
 	/* TODO: Implement strcpy(). */
-
 	return destination;
 }
 
 char *strncpy(char *destination, const char *source, size_t len)
 {
 	/* TODO: Implement strncpy(). */
-
 	return destination;
 }
 
 char *strcat(char *destination, const char *source)
 {
 	/* TODO: Implement strcat(). */
-
 	return destination;
 }
 
 char *strncat(char *destination, const char *source, size_t len)
 {
 	/* TODO: Implement strncat(). */
-
 	return destination;
 }
 
@@ -55,14 +51,12 @@ size_t strlen(const char *str)
 char *strchr(const char *str, int c)
 {
 	/* TODO: Implement strchr(). */
-
 	return NULL;
 }
 
 char *strrchr(const char *str, int c)
 {
 	/* TODO: Implement strrchr(). */
-
 	return NULL;
 }
 
@@ -81,14 +75,12 @@ char *strrstr(const char *haystack, const char *needle)
 void *memcpy(void *destination, const void *source, size_t num)
 {
 	/* TODO: Implement memcpy(). */
-
 	return destination;
 }
 
 void *memmove(void *destination, const void *source, size_t num)
 {
 	/* TODO: Implement memmove(). */
-
 	return destination;
 }
 
@@ -101,6 +93,5 @@ int memcmp(const void *ptr1, const void *ptr2, size_t num)
 void *memset(void *source, int value, size_t num)
 {
 	/* TODO: Implement memset(). */
-
 	return source;
 }


### PR DESCRIPTION
Remove spacing between `TODO` comments and existing code. This is for consistency throughout the assignment skeleton.