### PR TITLE
`asg/mini-libc`: Include `internal/syscall.h` in stat files

### DIFF
--- a/content/assignments/mini-libc/src/stat/fstat.c
+++ b/content/assignments/mini-libc/src/stat/fstat.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <sys/stat.h>
+#include <internal/syscall.h>
 #include <errno.h>
 
 int fstat(int fd, struct stat *st)

--- a/content/assignments/mini-libc/src/stat/stat.c
+++ b/content/assignments/mini-libc/src/stat/stat.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <sys/stat.h>
+#include <internal/syscall.h>
 #include <fcntl.h>
 #include <errno.h>
 


### PR DESCRIPTION
Reference solution for implementing `stat()` and `fstat()` relies on system call being made. Include `internal/syscall.h` in corresponding source code files to provide the `syscall()` function.