### PR TITLE
`asg/mini-libc/tests`: Use available locale `LC_ALL=C`

### DIFF
--- a/content/assignments/mini-libc/tests/run_all_tests.sh
+++ b/content/assignments/mini-libc/tests/run_all_tests.sh
@@ -38,6 +38,6 @@ total_grade=$( (echo "scale=0"; echo "$total / 10") | bc )
 echo ""
 echo -n "Total:                           "
 echo -n "                                "
-LC_ALL=en_US.UTF-8 printf "%3d/100\n" "$total_grade"
+LC_ALL=C printf "%3d/100\n" "$total_grade"
 
 rm results.txt


### PR DESCRIPTION
The `tests/run_all_tests.sh` script uses the `en_US.UTF-8` locale. This may not be available on certain systems, requiring installation. Replace it with the use of the generally available `C` locale.