### PR TITLE
workflows: Use main branch

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,7 +3,7 @@ name: Linter Actions Workflow
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   checkpatch:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,7 +3,7 @@ name: OpenEduHub - Github Page
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/os-runner.yml
+++ b/.github/workflows/os-runner.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'util/os-runner/**'
 
@@ -22,17 +22,17 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
The default branch of the repository was changed from `master` to `main`. Use `main` branch instead of `master` branch in all GitHub workflows.