### PR TITLE
`asg/minishell`: Improve source code Makefile

### DIFF
--- a/content/assignments/minishell/src/Makefile
+++ b/content/assignments/minishell/src/Makefile
@@ -1,17 +1,24 @@
-CC=gcc
-CFLAGS=-g -Wall
-OBJ_PARSER=../util/parser/parser.tab.o ../util/parser/parser.yy.o
-OBJ=main.o cmd.o utils.o
-TARGET=mini-shell
-.PHONY=build clean build_parser
+UTIL_PATH ?= ../util
+CPPFLAGS += -I.
+CC = gcc
+CFLAGS = -g -Wall
+OBJ_PARSER = $(UTIL_PATH)/parser/parser.tab.o $(UTIL_PATH)/parser/parser.yy.o
+OBJ = main.o cmd.o utils.o
+TARGET = mini-shell
+.PHONY = build clean build_parser
 
-build: $(TARGET)
+all: $(TARGET)
 
 $(TARGET): build_parser $(OBJ) $(OBJ_PARSER)
 	$(CC) $(CFLAGS) $(OBJ) $(OBJ_PARSER) -o $(TARGET)
 
 build_parser:
-	$(MAKE) -C ../util/parser/
+	$(MAKE) -C $(UTIL_PATH)/parser/
+
+pack: clean
+	-rm -f ../src.zip
+	zip -r ../src.zip *
 
 clean:
-	rm -rf $(OBJ) $(OBJ_PARSER) $(TARGET) *~
+	-rm -f ../src.zip
+	-rm -rf $(OBJ) $(OBJ_PARSER) $(TARGET) *~


### PR DESCRIPTION
Improve the `Makefile` used to build the source code. Improve layout, indentation and spacing. Add configurable variables for build commands.