### PR TITLE
workflows: Fix PR deployment action

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: ./repo
+          ref: ${{ github.head_ref }}
+
       - run: |
           cd repo
           REF=$(echo ${{ github.event.number }} | sed 's/\//\\\//g')


### PR DESCRIPTION
Fix PR deployment action by use the head_ref for checkout action in order to grab the PR base branch.