### PR TITLE
Propagate changes to the repo's layout to the `README.md` and labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,17 +1,17 @@
 topic/software-stack:
-  - 'content/chapters/software-stack/**/*'
+  - 'content/software-stack/**/*'
 
 topic/data:
-  - 'content/chapters/data/**/*'
+  - 'content/data/**/*'
 
 topic/compute:
-  - 'content/chapters/compute/**/*'
+  - 'content/compute/**/*'
 
 topic/io:
-  - 'content/chapters/io/**/*'
+  - 'content/io/**/*'
 
 topic/app-interact:
-  - 'content/chapters/app-interact/**/*'
+  - 'content/app-interact/**/*'
 
 area/quiz:
   - '**/quiz/*'

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ They are to be used by teachers, trainers, students and hobbyists who want to le
 Content is located in the `content/` folder.
 It currently consists of 5 chapters:
 
-* [Software Stack](content/chapters/software-stack/)
-* [Data](content/chapters/data/)
-* [Compute](content/chapters/compute/)
-* [Input/Output](content/chapters/io/)
-* [Application Interaction](content/chapters/app-interact/)
+* [Software Stack](content/software-stack/)
+* [Data](content/data/)
+* [Compute](content/compute/)
+* [Input/Output](content/io/)
+* [Application Interaction](content/app-interact/)
 
 Each chapter has its own folder.
 Content for each chapter is split in two subfolders:


### PR DESCRIPTION
PR #317 restructured the repository. A part of its changes meant removing the `chapters` directory. This commit fixes #340 by removing mentions to it from the `README.md` and from the labeler action.