### PR TITLE
Add basic .yml file for cs-pub-ro -> oeh sync

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,9 @@
+version: "1"
+rules:
+  - base: main
+    upstream: cs-pub-ro:main
+    mergeMethod: none
+    assignees:
+      - teodutu
+    reviewers:
+      - gabrielmocanu


### PR DESCRIPTION
This `pull.yml` file is the base file for the cs-pub-ro / open-education-hub synchronization. Related to #338 